### PR TITLE
Always use `conda info` to find prefix instead of environment

### DIFF
--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -51,9 +51,7 @@ def conda_prefix():
 def global_data_dir():
     """Return the global Intake catalog dir for the current environment"""
 
-    if CONDA_VAR in os.environ:
-        prefix = os.environ[CONDA_VAR]
-    elif VIRTUALENV_VAR in os.environ:
+    if VIRTUALENV_VAR in os.environ:
         prefix = os.environ[VIRTUALENV_VAR]
     else:
         prefix = conda_prefix()

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -43,7 +43,7 @@ def conda_prefix():
     """Fallback: ask conda in PATH for its prefix"""
     try:
         out = subprocess.check_output(['conda', 'info', '--json'])
-        return json.loads(out.decode())["conda_prefix"]
+        return json.loads(out.decode())["default_prefix"]
     except (subprocess.CalledProcessError, json.JSONDecodeError):
         return False
 

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -28,14 +28,6 @@ def user_catalog():
     os.remove(target_catalog)
 
 
-@pytest.fixture
-def env_catalog():
-    conda_env_dir = os.path.join(os.environ.get('CONDA_PREFIX', '/tmp'), 'share', 'intake')
-    target_catalog = copy_test_file('catalog2.yml', conda_env_dir)
-    yield target_catalog
-    os.remove(target_catalog)
-
-
 def test_autoregister_open():
     assert hasattr(intake, 'open_csv')
 
@@ -50,15 +42,3 @@ def test_user_catalog(user_catalog):
     cat = intake.load_combo_catalog()
     time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
-
-
-def test_env_catalog(env_catalog):
-    cat = intake.load_combo_catalog()
-    time.sleep(2) # wait 2 seconds for catalog to refresh
-    assert set(cat) >= set(['ex3', 'ex4'])
-
-
-def test_user_and_env_catalog(user_catalog, env_catalog):
-    cat = intake.load_combo_catalog()
-    time.sleep(2) # wait 2 seconds for catalog to refresh
-    assert set(cat) >= set(['ex1', 'ex2', 'ex3', 'ex4'])


### PR DESCRIPTION
Fixes #48