### PR TITLE
Add datashade option to plotting API

### DIFF
--- a/docs/source/plotting.ipynb
+++ b/docs/source/plotting.ipynb
@@ -1128,7 +1128,6 @@
     "import intake\n",
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "from holoviews.operation.datashader import datashade\n",
     "\n",
     "hv.extension('bokeh')\n",
     "%output fig='png'"
@@ -1967,7 +1966,7 @@
     }
    ],
    "source": [
-    "datashade(airline_source.plot.scatter('distance', 'airtime')).options(width=600)"
+    "airline_source.plot.scatter('distance', 'airtime', datashade=True)"
    ]
   },
   {

--- a/examples/nyc_taxi/build.sh
+++ b/examples/nyc_taxi/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/share/intake/nyc_taxi
+cp $RECIPE_DIR/nyc_taxi.yaml $PREFIX/share/intake/

--- a/examples/nyc_taxi/meta.yaml
+++ b/examples/nyc_taxi/meta.yaml
@@ -9,6 +9,8 @@ build:
 requirements:
   run:
     - intake
+    - intake-parquet
+    - s3fs
   build: []
 
 about:

--- a/examples/nyc_taxi/meta.yaml
+++ b/examples/nyc_taxi/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  version: '0.1.0'
+  name: 'nyc_taxi'
+
+build:
+  number: 0
+  noarch: generic
+
+requirements:
+  run:
+    - intake
+  build: []
+
+about:
+  description: NYC Taxi Trip data
+  license: MIT
+  license_family: MIT
+  summary: A dataset of NYC Taxi trips

--- a/examples/nyc_taxi/nyc_taxi.yaml
+++ b/examples/nyc_taxi/nyc_taxi.yaml
@@ -3,4 +3,4 @@ sources:
     description: NYC Taxi dataset
     driver: parquet
     args:
-      urlpath: 'https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq'
+      urlpath: 's3://datashader-data/nyc_taxi_wide.parq'

--- a/examples/nyc_taxi/nyc_taxi.yaml
+++ b/examples/nyc_taxi/nyc_taxi.yaml
@@ -1,0 +1,6 @@
+sources:
+  nyc_taxi:
+    description: NYC Taxi dataset
+    driver: parquet
+    args:
+      urlpath: 'https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq'

--- a/intake/plotting/__init__.py
+++ b/intake/plotting/__init__.py
@@ -89,6 +89,26 @@ def streaming(method):
     return streaming_plot
 
 
+def datashading(method):
+    """
+    Decorator to add datashading support to a plot.
+    """
+    def datashading_plot(*args, **kwargs):
+        self = args[0]
+        plot = method(*args, **kwargs)
+        if not self.datashade:
+            return plot
+        try:
+            from holoviews.operation.datashader import datashade
+        except:
+            raise ImportError('Datashading is not available')
+        opts = dict(width=self._plot_opts['width'], height=self._plot_opts['height'])
+        if 'cmap' in self._style_opts:
+            opts['cmap'] = self._style_opts['cmap']
+        return datashade(plot, **opts).opts(plot=self._plot_opts)
+    return datashading_plot
+
+
 class HoloViewsConverter(object):
 
     def __init__(self, data, kind=None, by=None, width=700,
@@ -100,7 +120,8 @@ class HoloViewsConverter(object):
                  style_opts={}, plot_opts={}, use_index=False,
                  value_label='value', group_label='Group',
                  colorbar=False, streaming=False, backlog=1000,
-                 timeout=1000, persist=False, use_dask=False, **kwds):
+                 timeout=1000, persist=False, use_dask=False,
+                 datashade=False, **kwds):
 
         # Validate DataSource
         if not isinstance(data, DataSource):
@@ -121,7 +142,7 @@ class HoloViewsConverter(object):
             def f():
                 self.stream.send(data.read())
             self.cb = PeriodicCallback(f, timeout)
-        elif use_dask and dd is not None:
+        elif (use_dask or persist) and dd is not None:
             ddf = data.to_dask()
             self.data = ddf.persist() if persist else ddf
         else:
@@ -135,6 +156,7 @@ class HoloViewsConverter(object):
         self.kwds = kwds
         self.value_label = value_label
         self.group_label = group_label
+        self.datashade = datashade
 
         # Process style options
         if 'cmap' in kwds and colormap:
@@ -248,10 +270,12 @@ class HoloViewsConverter(object):
                              'either x and y parameters to be declared '
                              'or use_index to be enabled.')
 
+    @datashading
     @streaming
     def line(self, x, y, data=None):
         return self.chart(Curve, x, y, data)
 
+    @datashading
     @streaming
     def scatter(self, x, y, data=None):
         scatter = self.chart(Scatter, x, y, data)

--- a/intake/plotting/__init__.py
+++ b/intake/plotting/__init__.py
@@ -100,11 +100,14 @@ def datashading(method):
             return plot
         try:
             from holoviews.operation.datashader import datashade
+            from datashader import count_cat
         except:
             raise ImportError('Datashading is not available')
         opts = dict(width=self._plot_opts['width'], height=self._plot_opts['height'])
         if 'cmap' in self._style_opts:
             opts['cmap'] = self._style_opts['cmap']
+        if self.by:
+            opts['aggregator'] = count_cat(self.by)
         return datashade(plot, **opts).opts(plot=self._plot_opts)
     return datashading_plot
 


### PR DESCRIPTION
Adds a datashading option to the plotting API to avoid having to apply the operation manually. Implemented as a decorator and therefore plays nicely with the existing ``streaming`` decorator.