### PR TITLE
RFC: Sub cats

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -107,7 +107,7 @@ class LocalState(State):
 
     def refresh(self):
         cfg = CatalogConfig(self.observable)
-        return cfg.name, {}, cfg.entries, cfg.plugins
+        return cfg.name, cfg.cats, cfg.entries, cfg.plugins
 
     def changed(self):
         return self.update_modification_time(os.path.getmtime(self.observable))

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -559,7 +559,9 @@ class CatalogParser(object):
 
         return dict(
             plugin_sources=self._parse_plugins(data),
-            data_sources=self._parse_data_sources(data))
+            data_sources=self._parse_data_sources(data),
+            catalogs=data.get('catalogs', {})
+        )
 
 
 class CatalogConfig(object):
@@ -605,6 +607,11 @@ class CatalogConfig(object):
             entry.find_plugin(self._plugins)
             self._entries[entry.name] = entry
 
+        self._cats = {}
+        for entry in cfg['catalogs']:
+            from intake import Catalog
+            self._cats[entry['name']] = Catalog(entry['url'])
+
     @property
     def name(self):
         return self._name
@@ -616,3 +623,7 @@ class CatalogConfig(object):
     @property
     def entries(self):
         return self._entries
+
+    @property
+    def cats(self):
+        return self._cats


### PR DESCRIPTION
A simple implementation of catalogues that can point to other catalogs, and make them available as attributes for tab-completion. This allows for "index" cats, which can point to a combination of local and remote catalogs, and for hierarchical sources, rather than the flattening that happens when loading a directory of yamls. Also opens the door to data source engines, such as "all the known tables in postgresql" and other data providers.

Note that this implementation is not recommended as the final way to do it, just put here for conversation.
