### PR TITLE
Update example us_states.yml to use new schema

### DIFF
--- a/intake/cli/sample/us_states.yml
+++ b/intake/cli/sample/us_states.yml
@@ -1,5 +1,5 @@
 sources:
-  - name: states
+  states:
     description: US state information from [CivilServices](https://civil.services/)
     driver: csv
     args:


### PR DESCRIPTION
Hi,

it seems the .yml schema got changed recently, but the example didn't get updated so importing it fails. This should fix it.