### PR TITLE
Update catalog docs with new api

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -136,9 +136,9 @@ Then sources can be listed::
 
     list(cat)
 
-and data sources are loaded with ``get()``::
+and data sources are loaded via their name:
 
-    data = cat['entry_part1'].get(part='1')
+    data = cat.entry_part1(part='1')
 
 Intake also supports loading all of the files ending in ``.yml`` and ``.yaml`` in a directory::
 

--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -134,11 +134,11 @@ A Catalog can be loaded from a YAML file on the local filesystem by creating a C
 
 Then sources can be listed::
 
-    cat.list()
+    list(cat)
 
 and data sources are loaded with ``get()``::
 
-    data = cat.get('entry1_part', part='1')
+    data = cat['entry_part1'].get(part='1')
 
 Intake also supports loading all of the files ending in ``.yml`` and ``.yaml`` in a directory::
 


### PR DESCRIPTION
I'm just reading through the docs and noticed a few occasions where the examples don't work anymore.

The new versions are just my best guess and what seems to work, please update if there's a better way of doing this.