### PR TITLE
Nix explicit coersion to structured np.dtype

### DIFF
--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -1,5 +1,6 @@
 import msgpack
 import numpy
+import pickle
 import requests
 import six
 
@@ -91,6 +92,8 @@ class RemoteDataSource(DataSource):
     def _copy_attributes(self):
         for attr in ['datashape', 'dtype', 'shape', 'npartitions', 'metadata']:
             setattr(self, attr, getattr(self._real_source, attr))
+        if isinstance(self.dtype, bytes):
+            self.dtype = pickle.loads(self.dtype)
 
     def discover(self):
         self._open_source()
@@ -172,7 +175,10 @@ class RemoteDataSourceProxied(DataSource):
         if isinstance(dtype_descr, list):
             # Reformat because NumPy needs list of tuples
             dtype_descr = [tuple(x) for x in response['dtype']]
-        self.dtype = numpy.dtype(dtype_descr)
+        if isinstance(dtype_descr, bytes):
+            self.dtype = pickle.loads(dtype_descr)
+        else:
+            self.dtype = numpy.dtype(dtype_descr)
         self.shape = tuple(response['shape'])
         self.npartitions = response['npartitions']
         self.metadata = response['metadata']

--- a/intake/catalog/serializer.py
+++ b/intake/catalog/serializer.py
@@ -81,7 +81,7 @@ class ComboSerializer(object):
 
 
 # Insert in preference order
-picklers = [PickleSerializer(protocol) for protocol in range(pickle.HIGHEST_PROTOCOL + 1)]
+picklers = [PickleSerializer(protocol) for protocol in [2, 1]]
 serializers = [MsgPackSerializer()] + picklers
 format_registry = OrderedDict([(e.name, e) for e in serializers])
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -148,7 +148,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
 
                 response = dict(
                     datashape=source.datashape,
-                    dtype=pickle.dumps(source.dtype),
+                    dtype=pickle.dumps(source.dtype, 2),
                     shape=source.shape, container=source.container,
                     metadata=source.metadata, npartitions=source.npartitions,
                     source_id=source_id)

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -4,7 +4,7 @@ import time
 from uuid import uuid4
 
 import msgpack
-import numpy
+import pickle
 import tornado.gen
 import tornado.ioloop
 import tornado.web
@@ -22,14 +22,16 @@ class IntakeServer(object):
     def get_handlers(self):
         return [
             (r"/v1/info", ServerInfoHandler, dict(catalog=self._catalog)),
-            (r"/v1/source", ServerSourceHandler, dict(catalog=self._catalog, cache=self._cache)),
+            (r"/v1/source", ServerSourceHandler, dict(catalog=self._catalog,
+                                                      cache=self._cache)),
         ]
 
     def make_app(self):
         handlers = get_browser_handlers(self._catalog) + self.get_handlers()
         return tornado.web.Application(handlers)
 
-    def start_periodic_functions(self, close_idle_after=None, remove_idle_after=None):
+    def start_periodic_functions(self, close_idle_after=None,
+                                 remove_idle_after=None):
         if len(self._periodic_callbacks) > 0:
             raise Exception('Periodic functions already started for this server')
 
@@ -84,7 +86,8 @@ class SourceCache(object):
     def add(self, source):
         source_id = str(uuid4())
         now = time.time()
-        self._sources[source_id] = dict(source=source, open_time=now, last_time=now)
+        self._sources[source_id] = dict(source=source, open_time=now,
+                                        last_time=now)
         return source_id
 
     def get(self, uuid):
@@ -93,7 +96,7 @@ class SourceCache(object):
         return record['source']
 
     def peek(self, uuid):
-        '''Get the source but do not change the last access time'''
+        """Get the source but do not change the last access time"""
         return self._sources[uuid]['source']
 
     def touch(self, uuid):
@@ -131,7 +134,8 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             client_plugins = request.get('available_plugins', [])
 
             # Can the client directly access the data themselves?
-            open_desc = self._catalog[entry_name].describe_open(**user_parameters)
+            open_desc = self._catalog[entry_name].describe_open(
+                **user_parameters)
             direct_access = open_desc['direct_access']
             plugin_name = open_desc['plugin']
             client_has_plugin = plugin_name in client_plugins
@@ -143,15 +147,18 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                 source_id = self._cache.add(source)
 
                 response = dict(
-                    datashape=source.datashape, dtype=numpy.dtype(source.dtype).descr,
+                    datashape=source.datashape,
+                    dtype=pickle.dumps(source.dtype),
                     shape=source.shape, container=source.container,
                     metadata=source.metadata, npartitions=source.npartitions,
                     source_id=source_id)
                 self.write(msgpack.packb(response, use_bin_type=True))
                 self.finish()
             elif direct_access == 'force' and not client_has_plugin:
-                msg = 'client must have plugin "%s" to access source "%s"' % (plugin_name, entry_name)
-                raise tornado.web.HTTPError(status_code=400, log_message=msg, reason=msg)
+                msg = 'client must have plugin "%s" to access source "%s"' \
+                      '' % (plugin_name, entry_name)
+                raise tornado.web.HTTPError(status_code=400, log_message=msg,
+                                            reason=msg)
             else:
                 # If we get here, the client can access the source directly
                 response = dict(
@@ -190,7 +197,8 @@ class ServerSourceHandler(tornado.web.RequestHandler):
 
         else:
             msg = '"%s" not a valid source action' % action
-            raise tornado.web.HTTPError(status_code=400, log_message=msg, reason=msg)
+            raise tornado.web.HTTPError(status_code=400, log_message=msg,
+                                        reason=msg)
 
     def _pick_encoder(self, accepted_formats, accepted_compression, container):
         format_encoder = None
@@ -201,7 +209,8 @@ class ServerSourceHandler(tornado.web.RequestHandler):
 
         if format_encoder is None:
             msg = 'Unable to find compatible format'
-            raise tornado.web.HTTPError(status_code=400, log_message=msg, reason=msg)
+            raise tornado.web.HTTPError(status_code=400, log_message=msg,
+                                        reason=msg)
 
         compressor = serializer.NoneCompressor()  # Default
         for f in accepted_compression:
@@ -214,7 +223,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
         error_exception = kwargs.get('exc_info', None)
         if error_exception is not None:
             print(error_exception)
-            msg = dict(error=error_exception[1].reason)
+            msg = dict(error=str(error_exception[1]))
         else:
             msg = dict(error='unknown error')
         self.write(msgpack.packb(msg, use_bin_type=True))

--- a/intake/container/dataframe.py
+++ b/intake/container/dataframe.py
@@ -3,6 +3,7 @@ import dask
 
 from .base import BaseContainer
 
+
 class DataFrame(BaseContainer):
 
     @staticmethod
@@ -11,8 +12,14 @@ class DataFrame(BaseContainer):
 
     @staticmethod
     def to_dask(parts, dtype):
-        # Construct metadata
-        meta = {name: arg[0] for name, arg in dtype.fields.items()}
+        # Compat: prefer dtype to already be meta-like, but can construct
+        # maybe should use dask.dataframe.utils.make_meta
+        if hasattr(dtype, 'fields'):
+            # compound np.dtype
+            meta = {name: arg[0] for name, arg in dtype.fields.items()}
+        else:
+            # dataframe or dict
+            meta = dtype
         return dask.dataframe.from_delayed(parts, meta=meta)
 
     @staticmethod

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -28,8 +28,22 @@ class Plugin(object):
         return base_kwargs, kwargs
 
 
-Schema = namedtuple('Schema', ['datashape', 'dtype', 'shape',
-                               'npartitions', 'extra_metadata'])
+class Schema(object):
+    """Holds details of data description for any type of data-source"""
+    def __init__(self, datashape=None, dtype=None, shape=None, npartitions=None,
+                 extra_metadata=None):
+        self.datashape = datashape
+        self.dtype = dtype
+        self.shape = shape
+        self.npartitions = npartitions
+        self.extra_metadata = extra_metadata
+
+    def __repr__(self):
+        return ("<Schema instance>\n"
+                "dtype: {}\n"
+                "shape: {}\n"
+                "metadata: {}"
+                "".format(self.dtype, self.shape, self.extra_metadata))
 
 
 class DataSource(object):

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -1,6 +1,4 @@
 import dask.dataframe
-import numpy as np
-
 from . import base
 
 
@@ -56,12 +54,10 @@ class CSVSource(base.DataSource):
                 self._urlpath, storage_options=self._storage_options,
                 **self._csv_kwargs)
 
-        dtypes = self._dataframe.dtypes
+        dtypes = self._dataframe._meta
         return base.Schema(datashape=None,
-                           dtype=np.dtype(list(zip(dtypes.index, dtypes))),
-                           # Shape not known without parsing all the files,
-                           # so leave it as 1D unknown
-                           shape=(None,),
+                           dtype=dtypes,
+                           shape=(None, len(dtypes.columns)),
                            npartitions=self._dataframe.npartitions,
                            extra_metadata={})
 

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -48,11 +48,10 @@ def test_open(data_filenames):
 def test_discover(sample1_datasource):
     info = sample1_datasource.discover()
 
-    assert info['dtype'] == np.dtype([('name', 'O'),
-                                      ('score', 'f8'),
-                                      ('rank', 'i8')])
+    assert info['dtype'].dtypes.to_dict() == {'name': 'O', 'score': 'f8',
+                                              'rank': 'i8'}
     # Do not know length without parsing CSV
-    assert info['shape'] == (None,)
+    assert info['shape'] == (None, 3)
     assert info['npartitions'] == 1
 
 


### PR DESCRIPTION
Allow pickling of the dtype object, allowing for passing of dataframe
metas or xarrays.

Fixes #63 (although it would be good to have that as an explicit test too)