### PR TITLE
Add metadata section to cat files

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -16,6 +16,8 @@ Intake catalogs are described with YAML files.  Here is an example:
 
 .. code-block:: yaml
 
+    metadata:
+      version: 1
     sources:
       example:
         description: test  
@@ -52,6 +54,13 @@ that same name. Some additional values are always available:
 
 - ``CATALOG_DIR``: The full path to the directory containing the YAML catalog file.  This is especially useful for constructing paths relative to the catalog directory to locate data files and custom plugins.
 
+Metadata
+''''''''
+
+Arbitrary extra descriptive information can go into the metadata section. Some fields will be
+claimed for internal use and some fields may be restricted to local reading; but for now the only
+field that is expected is ``version``, which will be updated when a breaking change is made to the
+file format. Any catalog will have ``.metadata`` and ``.version`` attributes available.
 
 Extra Plugins
 '''''''''''''

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -462,7 +462,9 @@ class CatalogParser(object):
 
         return dict(
             plugin_sources=self._parse_plugins(data),
-            data_sources=self._parse_data_sources(data))
+            data_sources=self._parse_data_sources(data),
+            metadata=data.get('metadata', {})
+        )
 
 
 class CatalogConfig(object):
@@ -511,6 +513,8 @@ class CatalogConfig(object):
         for entry in cfg['data_sources']:
             entry.find_plugin(self._plugins)
             self._entries[entry.name] = entry
+
+        self.metadata = cfg.get('metadata', {})
 
     @property
     def name(self):

--- a/intake/catalog/tests/catalog1.yml
+++ b/intake/catalog/tests/catalog1.yml
@@ -1,3 +1,5 @@
+metadata:
+  test: true
 plugins:
   source:
     - module: intake.catalog.tests.example1_source

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -59,6 +59,12 @@ def test_source_plugin_config(catalog1):
     assert_items_equal(list(catalog1.plugins), ['example1', 'example2'])
 
 
+def test_metadata(catalog1):
+    assert hasattr(catalog1, 'metadata')
+    assert catalog1['metadata']['test'] is True
+    assert catalog1.version == 1
+
+
 def test_use_source_plugin_from_config(catalog1):
     catalog1['use_example1'].get()
 

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -40,6 +40,13 @@ def test_bad_url(intake_server):
         Catalog(bad_url)
 
 
+def test_metadata(intake_server):
+    catalog = Catalog(intake_server)
+    assert hasattr(catalog, 'metadata')
+    assert catalog['metadata']['test'] is True
+    assert catalog.version == 1
+
+
 def test_unknown_source(intake_server):
     catalog = Catalog(intake_server)
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -13,6 +13,7 @@ from .browser import get_browser_handlers
 from .config import conf
 from intake.catalog import serializer
 from intake.auth import get_auth_class
+from intake import __version__
 
 
 class IntakeServer(object):
@@ -86,7 +87,8 @@ class ServerInfoHandler(tornado.web.RequestHandler):
                     info['name'] = name
                     sources.append(info)
 
-            server_info = dict(version='0.0.1', sources=sources)
+            server_info = dict(version=__version__, sources=sources,
+                               metadata=self.catalog.metadata)
         else:
             msg = 'Access forbidden'
             raise tornado.web.HTTPError(status_code=403, log_message=msg,


### PR DESCRIPTION
Defaults to being empty, if not found. Docs suggests it should
specify a version.

Also provide a .version attribute to cat objects, which defaults to 1.

Fixes #75 