### PR TITLE
Allow remote catalogs

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -18,7 +18,7 @@ Intake catalogs are described with YAML files.  Here is an example:
 
     sources:
       example:
-        description: test  
+        description: test
         driver: random
         args: {}
 
@@ -163,9 +163,10 @@ Intake Catalog objects will automatically detect changes or new additions to cat
 Remote Catalogs
 ---------------
 
-Intake also includes a server which can share an Intake catalog over HTTP (or HTTPS with the help of a TLS-enabled reverse proxy).  From the user perspective, remote catalogs function identically to local catalogs::
+Intake also includes a server which can share an Intake catalog over HTTP
+(or HTTPS with the help of a TLS-enabled reverse proxy).  From the user perspective, remote catalogs function identically to local catalogs::
 
-    cat = Catalog('http://catalog1:5000')
+    cat = Catalog('intake://catalog1:5000')
     cat.list()
 
 The difference is that operations on the catalog translate to requests sent to the catalog server.  Catalog servers provide access to data sources in one of two modes:

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -44,7 +44,7 @@ You can use the catalog client (defined below) using:
 
 ::
 
-  >>> intake list http://localhost:5000
+  $ intake list intake://localhost:5000
   entry1
   entry1_part
   use_example1

--- a/intake/auth/secret.py
+++ b/intake/auth/secret.py
@@ -22,16 +22,18 @@ class SecretAuth(BaseAuth):
             secret = uuid.uuid1().hex
             logger.info('Random server secret: %s' % secret)
         self.secret = secret
-        self.key = key
+        self.key = key.lower()
 
     def allow_connect(self, header):
+        head2 = {k.lower(): v for k, v in header.items()}
         try:
-            return header.get(self.key, '') == self.secret
+            return head2.get(self.key, '') == self.secret
         except:
             return False
 
     def allow_access(self, header, source):
+        head2 = {k.lower(): v for k, v in header.items()}
         try:
-            return header.get(self.key, '') == self.secret
+            return head2.get(self.key, '') == self.secret
         except:
             return False

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -1,11 +1,10 @@
 import logging
-import os.path
 import time
 
 import msgpack
 import requests
 from requests.compat import urljoin, urlparse
-import six
+from dask.bytes import open_files
 
 from .local import CatalogConfig
 from .remote import RemoteCatalogEntry
@@ -44,25 +43,26 @@ class State(object):
 class DirectoryState(State):
     """The state of a directory of catalog files"""
 
-    def __init__(self, name, observable, ttl, getenv=True, getshell=True):
+    def __init__(self, name, observable, ttl, getenv=True, getshell=True,
+                 storage_options=None):
         super(DirectoryState, self).__init__(name, observable, ttl,
                                              getenv=getenv, getshell=getshell)
         self.catalogs = []
+        self.storage_options = storage_options
         self._last_files = []
 
     def refresh(self):
         catalogs = []
+        self._last_files.clear()
 
-        if os.path.isdir(self.observable):
-            self._last_files = []
-            for f in os.listdir(self.observable):
-                if f.endswith('.yml') or f.endswith('.yaml'):
-                    path = os.path.join(self.observable, f)
-                    try:
-                        catalogs.append(Catalog(path))
-                        self._last_files.append(path)
-                    except Exception as e:
-                        logger.warning("%s: %s" % (str(e), f))
+        fns = (open_files(self.observable + '/*.yaml') +
+               open_files(self.observable + '/*.yml'))
+        for f in fns:
+            try:
+                self._last_files.append(f.path)
+                catalogs.append(Catalog(f))
+            except Exception as e:
+                logger.warning("%s: %s" % (str(e), f))
 
         self.catalogs = catalogs
         children = {catalog.name: catalog for catalog in self.catalogs}
@@ -70,13 +70,10 @@ class DirectoryState(State):
         return self.name, children, {}, []
 
     def changed(self):
-        if not os.path.isdir(self.observable):
-            return False
-        modified = self.update_modification_time(
-            os.path.getmtime(self.observable))
-        # Were any files removed?
-        modified = modified or any(not os.path.exists(filename)
-                                   for filename in self._last_files)
+        fns = (open_files(self.observable + '/*.yaml') +
+               open_files(self.observable + '/*.yml'))
+
+        modified = set(fn.path for fn in fns) != set(self._last_files)
         if modified:
             self.refresh()
         return any([modified] + [catalog.changed for catalog in self.catalogs])
@@ -85,10 +82,12 @@ class DirectoryState(State):
 class RemoteState(State):
     """The state of a remote Intake server"""
 
-    def __init__(self, name, observable, ttl, getenv=True, getshell=True):
+    def __init__(self, name, observable, ttl, getenv=True, getshell=True,
+                 http_args=None):
         super(RemoteState, self).__init__(name, observable, ttl,
                                           getenv=getenv, getshell=getshell)
-        self.base_url = observable + '/'
+        self.http_args = http_args or {}
+        self.base_url = observable.replace('intake', 'http') + '/'
         self.info_url = urljoin(self.base_url, 'v1/info')
         self.source_url = urljoin(self.base_url, 'v1/source')
 
@@ -96,7 +95,7 @@ class RemoteState(State):
         name = urlparse(self.observable).netloc.replace(
             '.', '_').replace(':', '_')
 
-        response = requests.get(self.info_url)
+        response = requests.get(self.info_url, **self.http_args)
         if response.status_code != 200:
             raise Exception('%s: status code %d' % (response.url,
                                                     response.status_code))
@@ -104,7 +103,8 @@ class RemoteState(State):
 
         entries = {s['name']: RemoteCatalogEntry(url=self.source_url,
                                                  getenv=self.getenv,
-                                                 getshell=self.getshell, **s)
+                                                 getshell=self.getshell,
+                                                 http_args=self.http_args, **s)
                    for s in info['sources']}
 
         return name, {}, entries, []
@@ -113,28 +113,33 @@ class RemoteState(State):
 class LocalState(State):
     """The state of a catalog file on the local filesystem"""
 
-    def __init__(self, name, observable, ttl, getenv=True, getshell=True):
+    def __init__(self, name, observable, ttl, getenv=True, getshell=True,
+                 storage_options=None):
+        self.storage_options = storage_options
         super(LocalState, self).__init__(name, observable, ttl,
                                          getenv=getenv, getshell=getshell)
 
     def refresh(self):
         cfg = CatalogConfig(self.observable, getenv=self.getenv,
-                            getshell=self.getshell)
+                            getshell=self.getshell,
+                            storage_options=self.storage_options)
         return cfg.name, {}, cfg.entries, cfg.plugins
 
     def changed(self):
-        return self.update_modification_time(os.path.getmtime(self.observable))
+        return False
 
 
 class CollectionState(State):
     """The state of a collection of other states"""
 
-    def __init__(self, name, observable, ttl, getenv=True, getshell=True):
+    def __init__(self, name, observable, ttl, getenv=True, getshell=True,
+                 storage_options=None):
         super(CollectionState, self).__init__(name, observable, ttl)
         # This name is a workaround to deal with issue that will be
         # solved in another PR
         self.catalogs = [Catalog(uri, name='cat%d' % i, getenv=getenv,
-                                 getshell=getshell)
+                                 getshell=getshell,
+                                 storage_options=storage_options)
                          for i, uri in enumerate(self.observable)]
 
     def refresh(self):
@@ -148,19 +153,33 @@ class CollectionState(State):
         return any([catalog.changed for catalog in self.catalogs])
 
 
-def create_state(name, observable, ttl, getenv=True, getshell=True):
+def create_state(name, observable, ttl, getenv=True, getshell=True,
+                 storage_options=None):
+    if observable is None or observable == []:
+        return State(name, observable, ttl)
     if isinstance(observable, list):
-        return CollectionState(name, observable, ttl, getenv=getenv,
-                               getshell=getshell)
-    elif observable.startswith('http://') or observable.startswith('https://'):
-        return RemoteState(name, observable, ttl, getenv=getenv,
-                           getshell=getshell)
-    elif observable.endswith('.yml') or observable.endswith('.yaml'):
+        if len(observable) > 1:
+            return CollectionState(name, observable, ttl, getenv=getenv,
+                                   getshell=getshell,
+                                   storage_options=storage_options)
+        if len(observable) == 0:
+            return Catalog()
+        observable = observable[0]
+    if isinstance(observable, str):
+        if observable.startswith('intake://'):
+            return RemoteState(name, observable, ttl, getenv=getenv,
+                               getshell=getshell, http_args=storage_options)
+        elif observable.endswith('.yml') or observable.endswith('.yaml'):
+            return LocalState(name, observable, ttl, getenv=getenv,
+                              getshell=getshell, storage_options=storage_options)
+        else:
+            return DirectoryState(name, observable, ttl, getenv=getenv,
+                                  getshell=getshell,
+                                  storage_options=storage_options)
+    else:
+        # try file-like
         return LocalState(name, observable, ttl, getenv=getenv,
                           getshell=getshell)
-    else:
-        return DirectoryState(name, observable, ttl, getenv=getenv,
-                              getshell=getshell)
 
 
 class Catalog(object):
@@ -191,17 +210,26 @@ class Catalog(object):
         ttl : float, optional
             Lifespan (time to live) of cached modification time. Units are in
             seconds. Defaults to 1.
+        storage_options : dict
+            If using a URL beginning with 'intake://' (remote Intake server),
+            parameters to pass to requests when issuing http commands; otherwise
+            parameters to pass to remote backend file-system. Ignored for
+            normal local files.
         """
         name = kwargs.get('name', None)
         ttl = kwargs.get('ttl', 1)
         self.getenv = kwargs.pop('getenv', True)
         self.getshell = kwargs.pop('getshell', True)
+        self.storage_options = kwargs.pop('storage_options', {})
 
-        args = list(flatten(args))
-        args = args[0] if len(args) == 1 else args
+        if all(isinstance(a, (tuple, list)) for a in args):
+            args = list(flatten(args))
+        if len(args) == 1:
+            args = args[0]
 
         self._state = create_state(name, args, ttl, getenv=self.getenv,
-                                   getshell=self.getshell)
+                                   getshell=self.getshell,
+                                   storage_options=self.storage_options)
         self.reload()
 
     def reload(self):

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -121,16 +121,15 @@ class LocalState(State):
         self.token = ''
 
     def refresh(self):
-        f = self.observable
-        cfg = CatalogConfig(f, getenv=self.getenv,
+        cfg = CatalogConfig(self.observable, getenv=self.getenv,
                             getshell=self.getshell,
                             storage_options=self.storage_options)
-        self.token = f.fs.ukey(f.path)
+        self.token = cfg.token
         return cfg.name, {}, cfg.entries, cfg.plugins
 
     def changed(self):
-        f = self.observable
-        token = f.fs.ukey(f.path)
+        token = CatalogConfig(self.observable, getenv=False, getshell=False,
+                              storage_options=self.storage_options).token
         return token != self.token
 
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -87,7 +87,9 @@ class RemoteState(State):
         super(RemoteState, self).__init__(name, observable, ttl,
                                           getenv=getenv, getshell=getshell)
         self.http_args = http_args or {}
-        self.base_url = observable.replace('intake', 'http') + '/'
+        secure = http_args.pop('ssl', False)
+        scheme = 'https' if secure else 'http'
+        self.base_url = observable.replace('intake', scheme) + '/'
         self.info_url = urljoin(self.base_url, 'v1/info')
         self.source_url = urljoin(self.base_url, 'v1/source')
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -118,15 +118,20 @@ class LocalState(State):
         self.storage_options = storage_options
         super(LocalState, self).__init__(name, observable, ttl,
                                          getenv=getenv, getshell=getshell)
+        self.token = ''
 
     def refresh(self):
-        cfg = CatalogConfig(self.observable, getenv=self.getenv,
+        f = self.observable
+        cfg = CatalogConfig(f, getenv=self.getenv,
                             getshell=self.getshell,
                             storage_options=self.storage_options)
+        self.token = f.fs.ukey(f.path)
         return cfg.name, {}, cfg.entries, cfg.plugins
 
     def changed(self):
-        return False
+        f = self.observable
+        token = f.fs.ukey(f.path)
+        return token != self.token
 
 
 class CollectionState(State):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -479,7 +479,11 @@ class CatalogConfig(object):
             file_open = open_files(self._path, mode='rb', **options)
             assert len(file_open) == 1
             file_open = file_open[0]
-        self.token = file_open.fs.ukey(file_open.path)
+        if file_open.path.startswith('http'):
+            # do not reload from HTTP
+            self.token = file_open.path
+        else:
+            self.token = file_open.fs.ukey(file_open.path)
         self._name = os.path.splitext(os.path.basename(
             self._path))[0].replace('.', '_')
         self._dir = os.path.dirname(self._path)

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -479,6 +479,7 @@ class CatalogConfig(object):
             file_open = open_files(self._path, mode='rb', **options)
             assert len(file_open) == 1
             file_open = file_open[0]
+        self.token = file_open.fs.ukey(file_open.path)
         self._name = os.path.splitext(os.path.basename(
             self._path))[0].replace('.', '_')
         self._dir = os.path.dirname(self._path)

--- a/intake/catalog/tests/conftest.py
+++ b/intake/catalog/tests/conftest.py
@@ -64,7 +64,7 @@ def intake_server(request):
             time.sleep(0.1)
             retries -= 1
 
-        yield url
+        yield 'intake://localhost:%d' % port
     finally:
         p.terminate()
         p.wait()

--- a/intake/catalog/tests/conftest.py
+++ b/intake/catalog/tests/conftest.py
@@ -5,7 +5,8 @@ import time
 import pytest
 import requests
 
-from intake.util_tests import ex
+from intake.util_tests import ex, PY2
+here = os.path.dirname(__file__)
 
 
 MIN_PORT = 7480
@@ -68,3 +69,26 @@ def intake_server(request):
     finally:
         p.terminate()
         p.wait()
+
+
+@pytest.fixture(scope='module')
+def http_server():
+    if PY2:
+        cmd = ['python', '-m', 'SimpleHTTPServer', '8000']
+    else:
+        cmd = ['python', '-m', 'http.server', '8000']
+    p = subprocess.Popen(cmd, cwd=here)
+    timeout = 5
+    while True:
+        try:
+            requests.get('http://localhost:8000/')
+            break
+        except:
+            time.sleep(0.1)
+            timeout -= 0.1
+            assert timeout > 0, "timeout waiting for http server"
+    try:
+        yield 'http://localhost:8000/'
+    finally:
+        p.terminate()
+        p.communicate()

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -326,3 +326,10 @@ def test_default_expansions():
 
     par = UserParameter('', '', 'int', default=1)
     par.expand_defaults()  # no error from string ops
+
+
+def test_remote_cat(http_server):
+    url = http_server + 'catalog1.yml'
+    cat = Catalog(url)
+    assert 'entry1' in cat
+    assert cat.entry1.describe()

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -128,7 +128,7 @@ class SourceCache(object):
     def remove_idle(self, idle_secs):
         threshold = time.time() - idle_secs
 
-        for uuid, record in self._sources.items().copy():
+        for uuid, record in self._sources.copy().items():
             if record['last_time'] < threshold:
                 del self._sources[uuid]
 

--- a/intake/util_tests.py
+++ b/intake/util_tests.py
@@ -11,7 +11,7 @@ import yaml
 ex = sys.executable
 here = os.path.dirname(__file__)
 defcat = os.path.join(here, 'cli', 'server', 'tests', 'catalog1.yml')
-
+PY2 = sys.version_info[0] == 2
 
 @contextmanager
 def tempdir():


### PR DESCRIPTION
- the URL for the intake server is now intake://

- general URLs like s3:// are now accepted

- Catalog has gained storage_options, which either are requests options
  for the server, or the usual options for the backend. This is, in
  practice, how you can provide auth headers for the server