### PR TITLE
Client auth

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - tornado
     - jinja2
     - ruamel_yaml >=0.15.0
-    - dask
+    - dask >=0.17.0
     - python-snappy
     - appdirs
 

--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -190,3 +190,8 @@ Whether a particular catalog entry supports direct or proxied access is determin
 - ``force``: Force all clients to access the data directly.  If they do not have the required plugin, an exception will be raised.
 
 Note that when the client is loading a data source via direct access, the catalog server will need to send the plugin arguments to the client.  Do not include sensitive credentials in a data source that allows direct access.
+
+Client Authorization Plugins
+''''''''''''''''''''''''''''
+
+Intake servers can check if clients are authorized to access the catalog as a whole, or individual catalog entries.  Typically a matched pair of server-side plugin (called an "auth plugin") and a client-side plugin (called a "client auth plugin) need to be enabled for authorization checks to work.  This feature is still in early development, so please `open a Github issue <https://github.com/ContinuumIO/intake/issues/new>`_ to discuss your use case before creating a plugin.

--- a/intake/auth/base.py
+++ b/intake/auth/base.py
@@ -30,3 +30,18 @@ class BaseAuth(object):
             The data source the user wants to access.
         """
         return True
+
+
+class BaseClientAuth(object):
+    """Base class for client-side setting of authorization headers
+
+    This basic class adds no headers to remote catalog reqests
+    """
+
+    def __init__(self, *args):
+        self.args = args
+
+    def get_headers(self):
+        """Returns a dictionary of HTTP headers to add to the remote catalog request.
+        """
+        return {}

--- a/intake/auth/base.py
+++ b/intake/auth/base.py
@@ -31,6 +31,18 @@ class BaseAuth(object):
         """
         return True
 
+    def get_case_insensitive(self, dictionary, key, default=None):
+        """Case-insensitive search of a dictionary for key.
+
+        Returns the value if key match is found, otherwise default.
+        """
+        lower_key = key.lower()
+        for k, v in dictionary.items():
+            if lower_key == k.lower():
+                return v
+        else:
+            return default
+
 
 class BaseClientAuth(object):
     """Base class for client-side setting of authorization headers

--- a/intake/auth/secret.py
+++ b/intake/auth/secret.py
@@ -26,25 +26,17 @@ class SecretAuth(BaseAuth):
 
     def allow_connect(self, header):
         try:
-            return self._get_case_insensitive(header, self.key, '') \
+            return self.get_case_insensitive(header, self.key, '') \
                         == self.secret
         except:
             return False
 
     def allow_access(self, header, source):
         try:
-            return self._get_case_insensitive(header, self.key, '') \
+            return self.get_case_insensitive(header, self.key, '') \
                         == self.secret
         except:
             return False
-
-    def _get_case_insensitive(self, dictionary, key, default=None):
-        lower_key = key.lower()
-        for k, v in dictionary.items():
-            if lower_key == k.lower():
-                return v
-        else:
-            return default
 
 
 class SecretClientAuth(BaseClientAuth):

--- a/intake/auth/secret.py
+++ b/intake/auth/secret.py
@@ -26,15 +26,25 @@ class SecretAuth(BaseAuth):
 
     def allow_connect(self, header):
         try:
-            return header.get(self.key, '') == self.secret
+            return self._get_case_insensitive(header, self.key, '') \
+                        == self.secret
         except:
             return False
 
     def allow_access(self, header, source):
         try:
-            return header.get(self.key, '') == self.secret
+            return self._get_case_insensitive(header, self.key, '') \
+                        == self.secret
         except:
             return False
+
+    def _get_case_insensitive(self, dictionary, key, default=None):
+        lower_key = key.lower()
+        for k, v in dictionary.items():
+            if lower_key == k.lower():
+                return v
+        else:
+            return default
 
 
 class SecretClientAuth(BaseClientAuth):

--- a/intake/auth/secret.py
+++ b/intake/auth/secret.py
@@ -1,5 +1,5 @@
 import logging
-from .base import BaseAuth
+from .base import BaseAuth, BaseClientAuth
 import uuid
 
 logger = logging.getLogger('intake')
@@ -35,3 +35,22 @@ class SecretAuth(BaseAuth):
             return header.get(self.key, '') == self.secret
         except:
             return False
+
+
+class SecretClientAuth(BaseClientAuth):
+    """Matching client auth plugin to SecretAuth
+
+    Parameters
+    ----------
+    secret: str
+        The string that must be included requests.
+    key: str
+        HTTP Header key for the shared secret
+    """
+
+    def __init__(self, secret, key='intake-secret'):
+        self.secret = secret
+        self.key = key
+
+    def get_headers(self):
+        return {self.key: self.secret}

--- a/intake/auth/tests/test_auth.py
+++ b/intake/auth/tests/test_auth.py
@@ -30,6 +30,8 @@ def test_secret():
     assert not auth.allow_connect({'intake-secret': None})
     assert not auth.allow_connect({'intake-secret': 'wrong'})
     assert auth.allow_connect({'intake-secret': secret})
+    # HTTP headers are not case sensitive, and frequently recapitalized
+    assert auth.allow_connect({'Intake-Secret': secret})
 
     assert not auth.allow_access({'intake-secret': 'wrong'}, None)
     assert auth.allow_access({'intake-secret': secret}, None)

--- a/intake/auth/tests/test_auth.py
+++ b/intake/auth/tests/test_auth.py
@@ -1,6 +1,6 @@
 
-from intake.auth.base import BaseAuth
-from intake.auth.secret import SecretAuth
+from intake.auth.base import BaseAuth, BaseClientAuth
+from intake.auth.secret import SecretAuth,SecretClientAuth
 from intake.auth import get_auth_class
 
 
@@ -11,10 +11,15 @@ def test_get():
     assert isinstance(auth, SecretAuth)
 
 
-def test_basic():
+def test_base():
     auth = BaseAuth()
     assert auth.allow_connect(None)
     assert auth.allow_access(None, None)
+
+
+def test_base_client():
+    auth = BaseClientAuth()
+    assert auth.get_headers() == {}
 
 
 def test_secret():
@@ -32,3 +37,12 @@ def test_secret():
     auth = SecretAuth(secret=secret, key='another_header')
     assert not auth.allow_connect({'intake-secret': secret})
     assert auth.allow_connect({'another_header': secret})
+
+
+def test_secret_client():
+    secret = 'test-secret'
+    auth = SecretClientAuth(secret=secret)
+    assert auth.get_headers() == { 'intake-secret': secret}
+
+    auth = SecretClientAuth(secret=secret, key='another_header')
+    assert auth.get_headers() == { 'another_header': secret}

--- a/intake/auth/tests/test_auth.py
+++ b/intake/auth/tests/test_auth.py
@@ -22,6 +22,21 @@ def test_base_client():
     assert auth.get_headers() == {}
 
 
+def test_base_get_case_insensitive():
+    auth = BaseAuth()
+    d = {'foo': 1, 'BAR': 2}
+    assert auth.get_case_insensitive(d, 'foo') == 1
+    assert auth.get_case_insensitive(d, 'Foo') == 1
+    assert auth.get_case_insensitive(d, 'FOO') == 1
+
+    assert auth.get_case_insensitive(d, 'bar') == 2
+    assert auth.get_case_insensitive(d, 'Bar') == 2
+    assert auth.get_case_insensitive(d, 'BAR') == 2
+
+    assert auth.get_case_insensitive(d, 'no') is None
+    assert auth.get_case_insensitive(d, 'no', '') == ''
+
+
 def test_secret():
     secret = 'test-secret'
     auth = SecretAuth(secret=secret)

--- a/intake/catalog/tests/conftest.py
+++ b/intake/catalog/tests/conftest.py
@@ -40,6 +40,7 @@ def pick_port():
 def intake_server(request):
     # Catalog path comes from the test module
     catalog_path = request.module.TEST_CATALOG_PATH
+    server_conf = getattr(request.module, 'TEST_SERVER_CONF', None)
 
     # Start a catalog server on nonstandard port
     port = pick_port()
@@ -52,6 +53,8 @@ def intake_server(request):
 
     env = dict(os.environ)
     env['INTAKE_TEST'] = 'server'
+    if server_conf is not None:
+        env['INTAKE_CONF_FILE'] = server_conf
 
     try:
         p = subprocess.Popen(cmd, env=env)

--- a/intake/catalog/tests/test_auth_integration.py
+++ b/intake/catalog/tests/test_auth_integration.py
@@ -1,0 +1,73 @@
+import os
+import os.path
+import shutil
+import tempfile
+import time
+
+import pytest
+
+from .util import assert_items_equal
+from intake.catalog import Catalog
+
+from intake.auth.secret import SecretClientAuth
+
+TMP_DIR = tempfile.mkdtemp()
+CONF_DIR = os.path.join(TMP_DIR, 'conf')
+os.mkdir(CONF_DIR)
+
+TEST_CATALOG_PATH = [TMP_DIR]
+YAML_FILENAME = 'intake_test_catalog.yml'
+
+
+# Create server configuration using shared-secret Auth
+TEST_SERVER_CONF = os.path.join(CONF_DIR, 'config.yaml')
+conf = '''
+auth:
+  class: intake.auth.secret.SecretAuth
+  kwargs:
+    secret: test_secret
+'''
+with open(TEST_SERVER_CONF, 'w') as f:
+    f.write(conf)
+
+
+def teardown_module(module):
+    shutil.rmtree(TMP_DIR)
+
+
+@pytest.fixture
+def intake_server_with_auth(intake_server):
+    fullname = os.path.join(TMP_DIR, YAML_FILENAME)
+
+    with open(fullname, 'w') as f:
+        f.write('''
+plugins:
+  source:
+    - module: intake.catalog.tests.example1_source
+    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+sources:
+  use_example1:
+    description: example1 source plugin
+    driver: example1
+    args: {}
+        ''')
+
+    time.sleep(2)
+
+    yield intake_server
+
+    os.remove(fullname)
+
+
+def test_secret_auth(intake_server_with_auth):
+    auth = SecretClientAuth(secret='test_secret')
+    catalog = Catalog(intake_server_with_auth, auth=auth)
+
+    entries = list(catalog)
+    assert entries == ['use_example1']
+
+
+def test_secret_auth_fail(intake_server_with_auth):
+    auth = SecretClientAuth(secret='test_wrong_secret')
+    with pytest.raises(Exception):
+        catalog = Catalog(intake_server_with_auth, auth=auth)

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -130,7 +130,8 @@ class SourceCache(object):
     def remove_idle(self, idle_secs):
         threshold = time.time() - idle_secs
 
-        for uuid, record in self._sources.items().copy():
+        # Make a copy of the items so we can mutate the dictionary
+        for uuid, record in list(self._sources.items()):
             if record['last_time'] < threshold:
                 del self._sources[uuid]
 


### PR DESCRIPTION
Most server-side authorization schemes (implemented by the auth plugins) will require matching client side code that can populate the HTTP headers of requests to the Intake server with some information.  This PR implements a minimal plugin API that queries a client auth plugin for extra HTTP headers prior to each call.

One subtle issue is that to enable serialization of data sources to remote workers, we have to freeze these headers when the RemoteDataSource is created, as we can't rely on the client auth plugin to work properly on the workers.  (There are likely use cases where this will be insufficient, but to resolve it we first need to decide on a reliable way to run Dask tasks back on the client, even when the client is not running a worker process in the Dask cluster.)

To do:
* [x] Integration test demonstrating that secret auth / client auth plugins cooperate properly
* ~~Client plugin discovery and configuration~~ (Not needed in this first pass)
* [x] Documentation