### PR TITLE
Auth plugin improvements

### DIFF
--- a/docs/source/auth-plugins.rst
+++ b/docs/source/auth-plugins.rst
@@ -1,0 +1,74 @@
+Authorization Plugins
+=====================
+
+Authorization plugins are classes that can be used to customize access permissions to the Intake catalog server.  The Intake server and client communicate over HTTP, so when security is a concern, the *most important* step to take is to put a TLS-enabled reverse proxy (like nginx) in front of the Intake server to encrypt all communication.
+
+Whether or not the connection is encrypted, the Intake server by default allows all clients to list the full catalog, and open any of the entries.  For many use cases, this is sufficient, but if the visibility of catalog entries needs to be limited based on some criteria, a server (and/or client) side authorization plugin can be used.
+
+Server Side
+-----------
+
+.. highlight: yaml
+
+An Intake server can have exactly one server side plugin enabled at startup.  The plugin is activated using the Intake configuration file, which lists the class name and the keyword arguments it takes.  For example, the "shared secret" plugin would be configured this way::
+
+    auth:
+      class: intake.auth.secret.Secret
+      kwargs:
+        secret: A_SECRET_HASH
+
+.. highlight: python
+
+The server auth plugin has two methods.  The ``allow_connect()`` method decides whether to allow a client to make any request to the server at all, and the ``allow_access()`` method decides whether the client is allowed to see a particular catalog entry in the listing and whether they are allowed to open that data source.  Note that for catalog entries which allow direct access to the data (via network or shared filesystem), the Intake authorization plugins have no impact on the visibility of the underlying data, only the entries in the catalog.
+
+The actual implementation of a plugin is very short.  Here is a simplified version of the shared secret auth plugin::
+
+    class SecretAuth(BaseAuth):
+        def __init__(self, secret, key='intake-secret'):
+            self.secret = secret
+            self.key = key
+    
+        def allow_connect(self, header):
+            try:
+                return self.get_case_insensitive(header, self.key, '') \
+                            == self.secret
+            except:
+                return False
+    
+        def allow_access(self, header, source, catalog):
+            try:
+                return self.get_case_insensitive(header, self.key, '') \
+                            == self.secret
+            except:
+                return False
+
+
+The `header` argument is a dictionary of HTTP headers that were present in the client request.  In this case, the plugin is looking for a special ``intake-secret`` header which contains the shared secret token.  Because HTTP header names are not case sensitive, the ``BaseAuth`` class provides a helper method ``get_case_insensitive()``, which will match dictionary keys in a case-insentive way.
+
+The ``allow_access`` method also takes two additional arguments.  The ``source`` argument is the instance of ``LocalCatalogEntry`` for the data source being checked.  Most commonly auth plugins will want to inspect the ``_metadata`` dictionary for information used to make the authorization decision.  Note that it is entirely up to the plugin author to decide what sections they want to require in the metadata section.  The ``catalog`` argument is the instance of ``Catalog`` that contains the catalog entry.  Typically, plugins will want to use information from the ``catalog.metadata`` dictionary to control global defaults, although this is also up to the plugin.
+
+
+Client Side
+-----------
+
+Although server side auth plugins can function entirely independently, some authorization schemes will require the client to add special HTTP headers for the server to look for.  To facilitate this, the Catalog constructor accepts an optional ``auth`` parameter with an instance of a client auth plugin class.
+
+The corresponding client plugin for the shared secret use case describe above looks like::
+
+    class SecretClientAuth(BaseClientAuth):
+        def __init__(self, secret, key='intake-secret'):
+            self.secret = secret
+            self.key = key
+    
+        def get_headers(self):
+            return {self.key: self.secret}
+
+It defines a single method, ``get_headers()``, which is called to get a dictionary of additional headers to add to the HTTP request to the catalog server.  To use this plugin, we would do the following::
+
+    import intake
+    from intake.auth.secret import SecretClientAuth
+
+    auth = SecretClientAuth('A_SECRET_HASH')
+    cat = intake.Catalog('http://example.com:5000', auth=auth)
+
+Now all requests made to the remote catalog will contain the ``intake-secret`` header.

--- a/docs/source/auth-plugins.rst
+++ b/docs/source/auth-plugins.rst
@@ -1,3 +1,5 @@
+.. _authplugins:
+
 Authorization Plugins
 =====================
 
@@ -18,6 +20,8 @@ An Intake server can have exactly one server side plugin enabled at startup.  Th
         secret: A_SECRET_HASH
 
 .. highlight: python
+
+For more information about configuring the Intake server, see :ref:`configuration`.
 
 The server auth plugin has two methods.  The ``allow_connect()`` method decides whether to allow a client to make any request to the server at all, and the ``allow_access()`` method decides whether the client is allowed to see a particular catalog entry in the listing and whether they are allowed to open that data source.  Note that for catalog entries which allow direct access to the data (via network or shared filesystem), the Intake authorization plugins have no impact on the visibility of the underlying data, only the entries in the catalog.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to Intake's documentation!
     catalog.rst
     tools.rst
     making-plugins.rst
+    auth-plugins.rst
     data-packages.rst
     plotting.ipynb
     plugin-directory.rst

--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -4,6 +4,8 @@ Command Line Tools
 The package installs two scripts: one for starting the catalog server and
 another is the client for accessing local or remote catalogs.
 
+.. _configuration:
+
 Configuration
 -------------
 
@@ -26,7 +28,7 @@ These are the defaults, and any parameters not specified will take the values ab
   see below)
 * and the auth system used will be the fully-qualified class given (which, for BaseAuth,
   always allows access). For further information on securing
-  the Intake Server, see the `auth documentation <auth.html>`_.
+  the Intake Server, see the :ref:`authplugins`.
 
 Intake Server
 -------------

--- a/intake/auth/base.py
+++ b/intake/auth/base.py
@@ -19,7 +19,7 @@ class BaseAuth(object):
         """
         return True
 
-    def allow_access(self, header, source):
+    def allow_access(self, header, source, catalog):
         """Is the given HTTP header allowed to access given data source
 
         Parameters
@@ -28,6 +28,8 @@ class BaseAuth(object):
             The HTTP header from the incoming request
         source: CatalogEntry
             The data source the user wants to access.
+        catalog: Catalog
+            The catalog object containing this data source.
         """
         return True
 

--- a/intake/auth/secret.py
+++ b/intake/auth/secret.py
@@ -31,7 +31,7 @@ class SecretAuth(BaseAuth):
         except:
             return False
 
-    def allow_access(self, header, source):
+    def allow_access(self, header, source, catalog):
         try:
             return self.get_case_insensitive(header, self.key, '') \
                         == self.secret

--- a/intake/auth/tests/test_auth.py
+++ b/intake/auth/tests/test_auth.py
@@ -14,7 +14,7 @@ def test_get():
 def test_base():
     auth = BaseAuth()
     assert auth.allow_connect(None)
-    assert auth.allow_access(None, None)
+    assert auth.allow_access(None, None, None)
 
 
 def test_base_client():
@@ -48,8 +48,8 @@ def test_secret():
     # HTTP headers are not case sensitive, and frequently recapitalized
     assert auth.allow_connect({'Intake-Secret': secret})
 
-    assert not auth.allow_access({'intake-secret': 'wrong'}, None)
-    assert auth.allow_access({'intake-secret': secret}, None)
+    assert not auth.allow_access({'intake-secret': 'wrong'}, None, None)
+    assert auth.allow_access({'intake-secret': secret}, None, None)
 
     auth = SecretAuth(secret=secret, key='another_header')
     assert not auth.allow_connect({'intake-secret': secret})

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -82,7 +82,7 @@ class ServerInfoHandler(tornado.web.RequestHandler):
         if self.auth.allow_connect(head):
             sources = []
             for _, name, source in self.catalog.walk():
-                if self.auth.allow_access(head, source):
+                if self.auth.allow_access(head, source, self.catalog):
                     info = source.describe()
                     info['name'] = name
                     sources.append(info)
@@ -151,7 +151,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
         if action == 'open':
             entry_name = request['name']
             entry = self._catalog[entry_name]
-            if not self.auth.allow_access(head, entry):
+            if not self.auth.allow_access(head, entry, self._catalog):
                 msg = 'Access forbidden'
                 raise tornado.web.HTTPError(status_code=403, log_message=msg,
                                             reason=msg)


### PR DESCRIPTION
* Pass catalog object to allow_access so that global attributes can be pull from the metadata section
* Document how to write and use auth plugins
* Add some cross reference links in the docs
