### PR TITLE
Turn storage_options['auth'] into a tuple always

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -132,7 +132,7 @@ fetched by running some external command. The special syntax are:
   value will come from the environment of the client.
 - ``shell(get_login thisuser -t)``: execute the command, and use the output as the value. The
   output will be trimmed of any trailing whitespace.
-- ``shell(get_login thisuser -t)``: exactly the same, except that when using a client-server
+- ``client_shell(get_login thisuser -t)``: exactly the same, except that when using a client-server
   topology, the value will come from the system of the client.
 
 Since it may not be desirable to have the access of

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -257,7 +257,7 @@ class Catalog(object):
         self.getshell = kwargs.pop('getshell', True)
         self.auth = kwargs.pop('auth', None)
 
-        if self.auth == None:
+        if self.auth is None:
             self.auth = BaseClientAuth()
 
         self.storage_options = kwargs.pop('storage_options', {})

--- a/intake/container/dataframe.py
+++ b/intake/container/dataframe.py
@@ -1,5 +1,3 @@
-import dask
-
 from .base import BaseContainer
 
 
@@ -12,6 +10,7 @@ class DataFrame(BaseContainer):
 
     @staticmethod
     def to_dask(parts, dtype):
+        import dask.dataframe
         # Compat: prefer dtype to already be meta-like, but can construct
         # maybe should use dask.dataframe.utils.make_meta
         if hasattr(dtype, 'fields'):

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -66,11 +66,13 @@ class DataSource(object):
         # automatically capture __init__ arguments for pickling
         o._captured_init_args = args
         o._captured_init_kwargs = kwargs
-        # monkey for requests auth= keyword
-        if 'storage_options' in kwargs and 'auth' in kwargs['storage_options']:
-            if isinstance(kwargs['storage_options']['auth'], list):
-                kwargs['storage_options']['auth'] = tuple(
-                    kwargs['storage_options']['auth'])
+
+        # monkey for requests keywords
+        for key in ['auth', 'verify']:
+            if 'storage_options' in kwargs and key in kwargs['storage_options']:
+                if isinstance(kwargs['storage_options'][key], list):
+                    kwargs['storage_options'][key] = tuple(
+                        kwargs['storage_options'][key])
         return o
 
     def __getstate__(self):

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -69,7 +69,9 @@ class DataSource(object):
 
         # monkey for requests keywords
         for key in ['auth', 'verify']:
-            if 'storage_options' in kwargs and key in kwargs['storage_options']:
+            if (kwargs and kwargs.get('storage_options', None)
+                    and key in kwargs['storage_options']):
+
                 if isinstance(kwargs['storage_options'][key], list):
                     kwargs['storage_options'][key] = tuple(
                         kwargs['storage_options'][key])

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -66,7 +66,11 @@ class DataSource(object):
         # automatically capture __init__ arguments for pickling
         o._captured_init_args = args
         o._captured_init_kwargs = kwargs
-
+        # monkey for requests auth= keyword
+        if 'storage_options' in kwargs and 'auth' in kwargs['storage_options']:
+            if isinstance(kwargs['storage_options']['auth'], list):
+                kwargs['storage_options']['auth'] = tuple(
+                    kwargs['storage_options']['auth'])
         return o
 
     def __getstate__(self):


### PR DESCRIPTION
This is because requests unconditionally wnats a tuple here,
but YAML parsing can only provide lists