### PR TITLE
Improvements for plotting API

### DIFF
--- a/examples/nyc_taxi/meta.yaml
+++ b/examples/nyc_taxi/meta.yaml
@@ -14,7 +14,7 @@ requirements:
   build: []
 
 about:
-  description: NYC Taxi Trip data
+  description: NYC Taxi Trip Data - January 2015
   license: MIT
   license_family: MIT
   summary: A dataset of NYC Taxi trips

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -37,6 +37,28 @@ def make_open_functions():
                           plugin_name)
 
 
+def output_notebook(inline=True, logo=False):
+    """
+    Load the notebook extension
+
+    Parameters
+    ----------
+    inline : boolean (optional)
+        Whether to inline JS code or load it from a CDN
+    logo : boolean (optional)
+        Whether to show the logo(s)
+    """
+    try:
+        import holoplot
+        import holoviews as hv
+    except:
+        raise ImportError("The intake plotting API requires holoplot."
+                          "holoplot may be installed with:\n\n"
+                          "`conda install -c pyviz holoplot` or "
+                          "`pip install holoplot`.")
+    hv.extension('bokeh', inline=inline, logo=logo)
+
+
 make_open_functions()
 
 # Import default catalog

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -206,3 +206,10 @@ class DataSource(object):
         metadata['fields'] = fields
         plots = self.metadata.get('plots', {})
         return HoloPlot(self, custom_plots=plots, **metadata)
+
+    @property
+    def holoplot(self):
+        """
+        Returns a HoloPlot object to provide a high-level plotting API.
+        """
+        return self.plot


### PR DESCRIPTION
This PR makes two changes:

1) Adds a ``output_notebook`` function at the top-level to load the holoviews notebook extension
2) Adds a ``.holoplot()`` API to datasources to mirror ``.plot()`` in case someone gets confused with the holoplot API.