### PR TITLE
Remote cats-of-cats

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 omit =
     */test_*.py
-    intake/_version.py
+    *_version.py
 source = 
     intake
 [report]

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     - intake list -h
     - intake-server -h
-    - py.test --cov=intake --pyargs -v intake
+    - py.test --pyargs intake
 
 about:
   home: https://github.com/ContinuumIO/intake

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -40,7 +40,7 @@ test:
   commands:
     - intake list -h
     - intake-server -h
-    - py.test --cov=intake --pyargs intake
+    - py.test --cov=intake --pyargs -v intake
 
 about:
   home: https://github.com/ContinuumIO/intake

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -22,7 +22,7 @@ API Reference
 
    .. attribute:: plot
 
-      Accessor for HoloPlot methods.  See :doc:`plotting` for more details.
+      Accessor for HVPlot methods.  See :doc:`plotting` for more details.
 
 .. autoclass:: intake.source.base.Plugin
    :members: open

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -19,8 +19,9 @@ from .source.discovery import autodiscover
 registry.update(autodiscover())
 
 # FIXME: this plugin needs to eventually be retired
-from .source import csv
+from .source import csv, textfiles
 registry['csv'] = csv.CSVSource
+registry['textfiles'] = textfiles.TextFilesSource
 registry['catalog'] = Catalog
 registry['intake_remote'] = RemoteCatalog
 
@@ -59,14 +60,14 @@ def output_notebook(inline=True, logo=False):
         Whether to show the logo(s)
     """
     try:
-        import holoplot
-        import holoviews as hv
-    except:
-        raise ImportError("The intake plotting API requires holoplot."
-                          "holoplot may be installed with:\n\n"
-                          "`conda install -c pyviz holoplot` or "
-                          "`pip install holoplot`.")
-    hv.extension('bokeh', inline=inline, logo=logo)
+        import hvplot
+    except ImportError:
+        raise ImportError("The intake plotting API requires hvplot."
+                          "hvplot may be installed with:\n\n"
+                          "`conda install -c pyviz hvplot` or "
+                          "`pip install hvplot`.")
+    import holoviews as hv
+    return hv.extension('bokeh', inline=inline, logo=logo)
 
 
 make_open_functions()

--- a/intake/auth/__init__.py
+++ b/intake/auth/__init__.py
@@ -3,6 +3,18 @@ import importlib
 
 
 def get_auth_class(auth, *args, **kwargs):
+    """Instantiate class from a string spec and arguments
+
+    Parameters
+    ----------
+    auth: str
+        Something like ``package.module.AuthClass``
+    args, kwargs: passed to the class's init function
+
+    Returns
+    -------
+    Instance of the given class
+    """
     mod, klass = auth.rsplit('.', 1)
     module = importlib.import_module(mod)
     cl = getattr(module, klass)

--- a/intake/auth/base.py
+++ b/intake/auth/base.py
@@ -3,6 +3,8 @@
 class BaseAuth(object):
     """Base class for authorization
 
+    Subclass this and override the methods to implement a new type of auth.
+
     This basic class allows all access.
     """
 
@@ -56,6 +58,6 @@ class BaseClientAuth(object):
         self.args = args
 
     def get_headers(self):
-        """Returns a dictionary of HTTP headers to add to the remote catalog request.
+        """Returns a dictionary of HTTP headers for the remote catalog request.
         """
         return {}

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -35,6 +35,7 @@ class Catalog(DataSource):
     """
     # emulate a DataSource
     container = 'catalog'
+    name = 'catalog'
 
     def __init__(self, *args, **kwargs):
         """
@@ -54,7 +55,7 @@ class Catalog(DataSource):
             parameters to pass to remote backend file-system. Ignored for
             normal local files.
         """
-        super(Catalog, self).__init__(container='catalog')
+        super(Catalog, self).__init__()
         self.name = kwargs.get('name', None)
         self.ttl = kwargs.get('ttl', 1)
         self.getenv = kwargs.pop('getenv', True)
@@ -130,10 +131,7 @@ class Catalog(DataSource):
 
     @reload_on_change
     def _get_entry(self, name):
-        try:
-            return self._entries[name]
-        except KeyError:
-            print('Not found:', name)
+        return self._entries[name]
 
     @reload_on_change
     def _get_entries(self):

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -117,7 +117,7 @@ class Catalog(DataSource):
         """
         out = sofar if sofar is not None else {}
         prefix = [] if prefix is None else prefix
-        for name, item in self._get_entries().items():
+        for name, item in self._entries.items():
             if item.container == 'catalog' and depth > 1:
                 # recurse with default open parameters
                 try:

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -14,24 +14,23 @@ logger = logging.getLogger('intake')
 
 
 class Catalog(DataSource):
-    """Manages a hierarchy of data sources and plugins as a collective unit.
+    """Manages a hierarchy of data sources as a collective unit.
 
-    A catalog is a set of available data sources and plugins for an individual
-    observed entity (remote server, local configuration file, or a local
-    directory of configuration files). This can be expanded to include a
+    A catalog is a set of available data sources for an individual
+    entity (remote server, local  file, or a local
+    directory of files). This can be expanded to include a
     collection of subcatalogs, which are then managed as a single unit.
 
     A catalog is created with a single URI or a collection of URIs. A URI can
     either be a URL or a file path.
 
     Each catalog in the hierarchy is responsible for caching the most recent
-    modification time of the respective observed entity to prevent overeager
-    queries.
+    refresh time to prevent overeager queries.
 
     Attributes
     ----------
     metadata : dict
-        Dictionary loaded from ``metadata`` section of catalog file.
+        Arbitrary information to carry along with the data source specs.
     """
     # emulate a DataSource
     container = 'catalog'
@@ -178,6 +177,18 @@ class RemoteCatalog(Catalog):
     """The state of a remote Intake server"""
 
     def __init__(self, url, http_args={}, **kwargs):
+        """Connect to remote Intake Server as a catalog
+
+        Parameters
+        ----------
+        url: str
+            Address of the server, e.g., "intake://localhost:5000".
+        http_args: dict
+            Arguments to add to HTTP calls, including "ssl" (True/False) for
+            secure connections.
+        kwargs: may include catalog name, metadata, source ID (if known) and
+            auth instance.
+        """
         self.http_args = http_args
         self.http_args.update(kwargs.get('storage_options', {}))
         self.http_args['headers'] = self.http_args.get('headers', {})
@@ -198,6 +209,7 @@ class RemoteCatalog(Catalog):
         super(RemoteCatalog, self).__init__(self, **kwargs)
 
     def _load(self):
+        """Fetch entries from remote"""
         # Add the auth headers to any other headers
         headers = self.http_args.get('headers', {})
         if self.auth is not None:

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-from .local import YAMLFilesCatalog
+from .local import YAMLFilesCatalog, Catalog
 
 
 def load_user_catalog():
@@ -13,7 +13,7 @@ def load_user_catalog():
     if not os.path.isdir(cat_dir):
         return Catalog()
     else:
-        return Catalog(cat_dir)
+        return YAMLFilesCatalog(cat_dir)
 
 
 def user_data_dir():
@@ -27,7 +27,7 @@ def load_global_catalog():
     if not os.path.isdir(cat_dir):
         return Catalog()
     else:
-        return Catalog(cat_dir)
+        return YAMLFilesCatalog(cat_dir)
 
 
 CONDA_VAR = 'CONDA_PREFIX'
@@ -97,6 +97,4 @@ def load_combo_catalog():
         cat_dirs.append(global_dir + '/*.yaml')
         cat_dirs.append(global_dir + '/*.yml')
 
-    # TODO: if we find no dirs or dirs are empty,
-    # Catalog should cope and return empty without this branching
     return YAMLFilesCatalog(cat_dirs)

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -77,6 +77,7 @@ class CatalogEntry(object):
         return self._default_source
 
     def __getattr__(self, attr):
+        # TODO: only consider attr not starting with "_"?
         return getattr(self._get_default_source(), attr)
 
     def __repr__(self):

--- a/intake/catalog/exceptions.py
+++ b/intake/catalog/exceptions.py
@@ -25,12 +25,14 @@ class EnvironmentPermissionDenied(PermissionDenied):
 
 
 class ValidationError(CatalogException):
+    """Something's wrong with the catalog spec"""
     def __init__(self, message, errors):
         super(ValidationError, self).__init__(message)
         self.errors = errors
 
 
 class DuplicateKeyError(ValidationError):
+    """Catalog contains key duplications"""
     def __init__(self, exception):
         line, column = exception.problem_mark.line, exception.problem_mark.column
         msg = "duplicate key found on line {}, column {}".format(line + 1, column + 1)

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -162,6 +162,8 @@ class LocalCatalogEntry(CatalogEntry):
     def get(self, **user_parameters):
         open_args = self._create_open_args(user_parameters)
         data_source = self._plugin(**open_args)
+        data_source.name = self.name
+        data_source.description = self._description
 
         return data_source
 
@@ -418,6 +420,7 @@ class YAMLFileCatalog(Catalog):
     version = __version__,
     container = 'catalog',
     partition_access = None
+    name = 'yaml_files_cat'
 
     def __init__(self, path, **kwargs):
         """
@@ -488,6 +491,7 @@ class YAMLFilesCatalog(Catalog):
     version = __version__,
     container = 'catalog',
     partition_access = None
+    name = 'yaml_file_cat'
 
     def __init__(self, path, flatten=True, **kwargs):
         """

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -71,6 +71,7 @@ class UserParameter(object):
                             for item in self.allowed]
 
     def describe(self):
+        """Information about this parameter"""
         desc = {
             'name': self.name,
             'description': self.description,
@@ -92,6 +93,7 @@ class UserParameter(object):
             self._default, client, getenv, getshell))
 
     def validate(self, value):
+        """Does value meet parameter requirements?"""
         value = coerce(self.type, value)
 
         if self.min is not None and value < self.min:
@@ -108,8 +110,35 @@ class UserParameter(object):
 
 
 class LocalCatalogEntry(CatalogEntry):
+    """A catalog entry on the local system
+    """
     def __init__(self, name, description, driver, direct_access, args,
                  parameters, metadata, catalog_dir, getenv=True, getshell=True):
+        """
+
+        Parameters
+        ----------
+        name: str
+            How this entry is known, normally from its key in a YAML file
+        description: str
+            Brief text about the target source
+        driver: str
+            Name of the plugin that can load this
+        direct_access: bool
+            Is the client allowed to attempt to reach this data
+        args: list
+            Passed when instantiating the plugin DataSource
+        parameters: list
+            UserParameters that can be set
+        metadata: dict
+            Additional information about this data
+        catalog_dir: str
+            Location of the catalog, if known
+        getenv: bool
+            Can parameter default fields take values from the environment
+        getshell: bool
+            Can parameter default fields run shell commands
+        """
         self._name = name
         self._description = description
         self._driver = driver
@@ -127,6 +156,7 @@ class LocalCatalogEntry(CatalogEntry):
         return self._name
 
     def describe(self):
+        """Basic information about this entry"""
         return {
             'container': self._plugin.container,
             'description': self._description,
@@ -160,6 +190,7 @@ class LocalCatalogEntry(CatalogEntry):
         }
 
     def get(self, **user_parameters):
+        """Instantiate the DataSource for the given parameters"""
         open_args = self._create_open_args(user_parameters)
         data_source = self._plugin(**open_args)
         data_source.name = self.name
@@ -193,6 +224,7 @@ yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
 
 
 class CatalogParser(object):
+    """Loads entries from a YAML spec"""
     def __init__(self, data, getenv=True, getshell=True, context=None):
         self._context = context if context else {}
         self._errors = []

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -417,8 +417,8 @@ def register_plugin_dir(path):
 
 class YAMLFileCatalog(Catalog):
     """Catalog as described by a single YAML file"""
-    version = __version__,
-    container = 'catalog',
+    version = __version__
+    container = 'catalog'
     partition_access = None
     name = 'yaml_files_cat'
 

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -24,6 +24,17 @@ class RemoteCatalogEntry(CatalogEntry):
     def describe(self):
         return self.kwargs
 
+    def describe_open(self, **kwargs):
+        import pdb
+        pdb.set_trace()
+        return {
+            'plugin': None,
+            'description': self._description,
+            'direct_access': False,
+            'metadata': self._metadata,
+            'args': (self.url, )
+        }
+
     def get(self, **user_parameters):
         for par in self.kwargs['user_parameters']:
             if par['name'] not in user_parameters:

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -8,7 +8,20 @@ from .utils import expand_defaults, coerce
 
 
 class RemoteCatalogEntry(CatalogEntry):
+    """An entry referring to a remote data definition"""
     def __init__(self, url, auth, *args, **kwargs):
+        """
+
+        Parameters
+        ----------
+        url: str
+            HTTP address of the Intake server this entry comes from
+        auth: Auth instance
+            If there are additional headers to add to calls, this instance will
+            provide them
+        kwargs: additional keys describing the entry, name, description,
+            container,
+        """
         self.url = url
         self.auth = auth
         self.args = args
@@ -22,11 +35,11 @@ class RemoteCatalogEntry(CatalogEntry):
                                                  getshell=getshell)
 
     def describe(self):
+        # likely not used
         return self.kwargs
 
     def describe_open(self, **kwargs):
-        import pdb
-        pdb.set_trace()
+        # likely not used
         return {
             'plugin': None,
             'description': self._description,

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -2,7 +2,6 @@ import msgpack
 import requests
 import six
 
-from ..container import container_map
 from ..source import registry as plugin_registry
 from .entry import CatalogEntry
 from .utils import expand_defaults, coerce
@@ -47,6 +46,7 @@ class RemoteCatalogEntry(CatalogEntry):
 
 def open_remote(url, entry, container, user_parameters, description, http_args):
     """Create either local direct data source or remote streamed source"""
+    from intake.container import container_map
     if url.startswith('intake://'):
         url = url[len('intake://'):]
     payload = dict(action='open',

--- a/intake/catalog/tests/catalog1.yml
+++ b/intake/catalog/tests/catalog1.yml
@@ -9,6 +9,11 @@ sources:
     description: example1 source plugin
     driver: example1
     args: {}
+  nested:
+    description: same again please
+    driver: yaml_file_cat
+    args:
+      path: '{{ CATALOG_DIR }}/catalog1.yml'
   entry1:
     description: entry1 full
     metadata:

--- a/intake/catalog/tests/catalog1.yml
+++ b/intake/catalog/tests/catalog1.yml
@@ -58,3 +58,8 @@ sources:
         description: none
         type: str
         default: 'client_env(INTAKE_TEST)'
+  text:
+    description: textfiles in this dir
+    driver: textfiles
+    args:
+      urlpath: "{{ CATALOG_DIR }}/*.yml"

--- a/intake/catalog/tests/conftest.py
+++ b/intake/catalog/tests/conftest.py
@@ -52,6 +52,15 @@ def intake_server(request):
     server_conf = getattr(request.module, 'TEST_SERVER_CONF', None)
 
     # Start a catalog server on nonstandard port
+
+    env = dict(os.environ)
+    env['INTAKE_TEST'] = 'server'
+    if server_conf is not None:
+        env['INTAKE_CONF_FILE'] = server_conf
+    yield from make_server(catalog_path, env)
+
+
+def make_server(catalog_path, env=None):
     port = pick_port()
     cmd = [ex, '-m', 'intake.cli.server', '--sys-exit-on-sigterm',
            '--port', str(port)]
@@ -59,12 +68,6 @@ def intake_server(request):
         cmd.extend(catalog_path)
     else:
         cmd.append(catalog_path)
-
-    env = dict(os.environ)
-    env['INTAKE_TEST'] = 'server'
-    if server_conf is not None:
-        env['INTAKE_CONF_FILE'] = server_conf
-
     try:
         p = subprocess.Popen(cmd, env=env)
         url = 'http://localhost:%d/v1/info' % (port,)

--- a/intake/catalog/tests/conftest.py
+++ b/intake/catalog/tests/conftest.py
@@ -57,10 +57,6 @@ def intake_server(request):
     env['INTAKE_TEST'] = 'server'
     if server_conf is not None:
         env['INTAKE_CONF_FILE'] = server_conf
-    yield from make_server(catalog_path, env)
-
-
-def make_server(catalog_path, env=None):
     port = pick_port()
     cmd = [ex, '-m', 'intake.cli.server', '--sys-exit-on-sigterm',
            '--port', str(port)]
@@ -74,7 +70,7 @@ def make_server(catalog_path, env=None):
 
         # wait for server to finish initalizing, but let the exception through
         # on last retry
-        retries = 500
+        retries = 10
         while not ping_server(url, swallow_exception=(retries > 1)):
             time.sleep(0.1)
             retries -= 1

--- a/intake/catalog/tests/example1_source.py
+++ b/intake/catalog/tests/example1_source.py
@@ -8,4 +8,4 @@ class ExampleSource(DataSource):
     partition_access = True
 
     def __init__(self, **kwargs):
-        super(ExampleSource, self).__init__(container='dataframe')
+        super(ExampleSource, self).__init__()

--- a/intake/catalog/tests/test_default.py
+++ b/intake/catalog/tests/test_default.py
@@ -1,0 +1,15 @@
+import sys
+from intake.catalog import default
+from intake.catalog.base import Catalog
+
+
+def test_which():
+    p = default.which('python')
+    assert p == sys.executable
+
+
+def test_load():
+    cat = default.load_user_catalog()
+    assert isinstance(cat, Catalog)
+    cat = default.load_global_catalog()
+    assert isinstance(cat, Catalog)

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -27,7 +27,7 @@ def catalog1():
 def test_local_catalog(catalog1):
     assert_items_equal(list(catalog1),
                        ['use_example1', 'nested', 'entry1', 'entry1_part',
-                        'remote_env', 'local_env'])
+                        'remote_env', 'local_env', 'text'])
     assert catalog1['entry1'].describe() == {
         'container': 'dataframe',
         'direct_access': 'forbid',

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -61,6 +61,8 @@ def test_nested(catalog1):
     assert 'nested' in catalog1
     assert 'entry1' in catalog1.nested.nested()
     assert catalog1.entry1.read().equals(catalog1.nested.nested.entry1.read())
+    assert 'nested.nested' not in catalog1.walk(depth=1)
+    assert 'nested.nested' in catalog1.walk(depth=2)
 
 
 def test_source_plugin_config(catalog1):

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -82,7 +82,8 @@ def test_read(intake_server):
 
     info = d.discover()
     assert info['datashape'] is None
-    assert info['dtype'].equals(meta)
+    assert info['dtype'] == {k: str(v) for k, v
+                             in meta.dtypes.to_dict().items()}
     assert info['npartitions'] == 2
     assert info['shape'] == (None, 3)  # Do not know CSV size ahead of time
 
@@ -105,7 +106,8 @@ def test_read_direct(intake_server):
     info = d.discover()
 
     assert info['datashape'] is None
-    assert info['dtype'].equals(meta)
+    assert info['dtype'] == {k: str(v) for k, v
+                             in meta.dtypes.to_dict().items()}
     assert info['npartitions'] == 1
     assert info['shape'] == (None, 3)  # Do not know CSV size ahead of time
     assert info['metadata'] == {'bar': [2, 4, 6], 'foo': 'baz'}

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -6,7 +6,6 @@ import pandas as pd
 
 from ...source.tests.util import verify_datasource_interface
 from .util import assert_items_equal
-from .conftest import make_server
 from intake import Catalog
 
 TEST_CATALOG_PATH = os.path.join(os.path.dirname(__file__), 'catalog1.yml')
@@ -17,7 +16,7 @@ def test_info_describe(intake_server):
 
     assert_items_equal(list(catalog), ['use_example1', 'nested', 'entry1',
                                        'entry1_part', 'remote_env',
-                                       'local_env'])
+                                       'local_env', 'text'])
 
     info = catalog['entry1'].describe()
 
@@ -207,13 +206,10 @@ def test_remote_env(intake_server):
     assert 'INTAKE_TEST' in str(e.value)
 
 
-def test_remote_sequence():
+def test_remote_sequence(intake_server):
     import glob
     d = os.path.dirname(TEST_CATALOG_PATH)
-    path = os.path.join(d, 'texts.yml')
-    i = iter(make_server(path))
-    server = next(i)
-    catalog = Catalog(server)
+    catalog = Catalog(intake_server)
     assert 'text' in catalog
     s = catalog.text()
     s.discover()

--- a/intake/catalog/tests/texts.yml
+++ b/intake/catalog/tests/texts.yml
@@ -1,6 +1,0 @@
-sources:
-  text:
-    description: textfiles in this dir
-    driver: textfiles
-    args:
-      urlpath: "{{ CATALOG_DIR }}/*.yml"

--- a/intake/catalog/tests/texts.yml
+++ b/intake/catalog/tests/texts.yml
@@ -1,0 +1,6 @@
+sources:
+  text:
+    description: textfiles in this dir
+    driver: textfiles
+    args:
+      urlpath: "{{ CATALOG_DIR }}/*.yml"

--- a/intake/catalog/utils.py
+++ b/intake/catalog/utils.py
@@ -12,6 +12,7 @@ import six
 
 def flatten(iterable):
     """Flatten an arbitrarily deep list"""
+    # likely not used
     iterable = iter(iterable)
     while True:
         try:

--- a/intake/cli/server/__main__.py
+++ b/intake/cli/server/__main__.py
@@ -42,8 +42,10 @@ def main(argv=None):
     for arg in args.catalog_args:
         logger.info('  - %s' % arg)
 
-    logger.info("catalog_args: %s" % args.catalog_args)
-    catalog = Catalog(args.catalog_args)
+    catargs = args.catalog_args
+    catargs = catargs[0] if len(catargs) == 1 else catargs
+    logger.info("catalog_args: %s" % catargs)
+    catalog = Catalog(catargs)
 
     logger.info('Entries:' + ','.join(list(catalog)))
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -88,7 +88,7 @@ class ServerInfoHandler(tornado.web.RequestHandler):
             else:
                 cat = self.catalog
             sources = []
-            for name, source in cat.walk().items():
+            for name, source in cat.walk(depth=1).items():
                 if self.auth.allow_access(head, source, self.catalog):
                     info = source.describe()
                     info['name'] = name

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -18,6 +18,7 @@ logger = logging.getLogger('intake')
 
 
 class IntakeServer(object):
+    """Main intake-server tornado application"""
     def __init__(self, catalog):
         self._catalog = catalog
         self._cache = SourceCache()
@@ -75,6 +76,7 @@ class IntakeServer(object):
 
 
 class ServerInfoHandler(tornado.web.RequestHandler):
+    """Basic info about the server"""
     def initialize(self, cache, catalog, auth):
         self.cache = cache
         self.catalog = catalog
@@ -104,6 +106,7 @@ class ServerInfoHandler(tornado.web.RequestHandler):
 
 
 class SourceCache(object):
+    """Stores DataSources requested by some user"""
     def __init__(self):
         self._sources = {}
 
@@ -146,6 +149,12 @@ class SourceCache(object):
 
 
 class ServerSourceHandler(tornado.web.RequestHandler):
+    """Open or stream data source
+
+    The requests "action" field (open|read) specified what the request wants
+    to do. Open caches the source and created an ID for it, read uses that
+    ID to reference the source and read a partition.
+    """
     def initialize(self, catalog, cache, auth):
         self._catalog = catalog
         self._cache = cache
@@ -193,7 +202,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                                                         source_id))
                 response = dict(
                     datashape=source.datashape,
-                    dtype=pickle.dumps(source.dtype, 2),
+                    dtype=source.dtype,
                     shape=source.shape, container=source.container,
                     metadata=source.metadata, npartitions=source.npartitions,
                     source_id=source_id)

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -94,8 +94,8 @@ class TestServerV1Source(TestServerV1Base):
 
         self.assertEqual(resp_msg['container'], 'dataframe')
         self.assertEqual(resp_msg['shape'], [None, 3])
-        expected_dtype = {'name': 'O', 'score': 'f8', 'rank': 'i8'}
-        actual_dtype = pickle.loads(resp_msg['dtype']).dtypes.to_dict()
+        expected_dtype = {'name': 'object', 'score': 'float64', 'rank': 'int64'}
+        actual_dtype = resp_msg['dtype']
         self.assertEqual(expected_dtype, actual_dtype)
         self.assertEqual(resp_msg['npartitions'], 2)
         self.assertEqual(resp_msg['metadata'], dict(foo='bar', bar=[1, 2, 3]))

--- a/intake/container/__init__.py
+++ b/intake/container/__init__.py
@@ -1,11 +1,13 @@
 from .dataframe import RemoteDataFrame
 from .ndarray import NdArray
 from .semistructured import RemoteSequenceSource
+from ..catalog.base import RemoteCatalog
 
 container_map = {
     'dataframe': RemoteDataFrame,
     'python': RemoteSequenceSource,
-    'ndarray': NdArray
+    'ndarray': NdArray,
+    'catalog': RemoteCatalog
 }
 
 __all__ = ['container_map']

--- a/intake/container/__init__.py
+++ b/intake/container/__init__.py
@@ -1,12 +1,14 @@
 from .dataframe import RemoteDataFrame
-from .ndarray import NdArray
+from .ndarray import RemoteArray
 from .semistructured import RemoteSequenceSource
 from ..catalog.base import RemoteCatalog
 
+# each container type is represented in the remote by one of the classes in
+# this dictionary
 container_map = {
     'dataframe': RemoteDataFrame,
     'python': RemoteSequenceSource,
-    'ndarray': NdArray,
+    'ndarray': RemoteArray,
     'catalog': RemoteCatalog
 }
 

--- a/intake/container/base.py
+++ b/intake/container/base.py
@@ -6,9 +6,26 @@ from intake import __version__
 
 
 class RemoteSource(DataSource):
+    """Base class for all DataSources living on an Intake server"""
     version = __version__
 
     def __init__(self, url, headers, name, parameters, metadata=None, **kwargs):
+        """
+
+        Parameters
+        ----------
+        url: str
+            Address of the server
+        headers: dict
+            HTTP headers to sue in calls
+        name: str
+            handle to reference this data
+        parameters: dict
+            To pass to the server when it instantiates the data source
+        metadata: dict
+            Additional info
+        kwargs: ignored
+        """
         super(RemoteSource, self).__init__(self)
         self.url = url
         self.name = name
@@ -52,6 +69,21 @@ class RemoteSource(DataSource):
 
 
 def get_partition(url, headers, source_id, container, partition):
+    """Serializable function for fetching a data source partition
+
+    Parameters
+    ----------
+    url: str
+        Server address
+    headers: dict
+        HTTP header parameters
+    source_id: str
+        ID of the source in the server's cache (unique per user)
+    container: str
+        Type of data, like "dataframe" one of ``intake.container.container_map``
+    partition: serializable
+        Part of data to fetch, e.g., an integer for a dataframe.
+    """
     accepted_formats = list(serializer.format_registry.keys())
     accepted_compression = list(serializer.compression_registry.keys())
     payload = dict(action='read',

--- a/intake/container/base.py
+++ b/intake/container/base.py
@@ -35,7 +35,7 @@ class RemoteSource(DataSource):
             # Reformat because NumPy needs list of tuples
             dtype_descr = [tuple(x) for x in response['dtype']]
         self.dtype = dtype_descr
-        self.shape = tuple(response['shape'])
+        self.shape = tuple(response['shape'] or ())
         self.npartitions = response['npartitions']
         self.metadata = response['metadata']
         self._schema = Schema(datashape=None, dtype=self.dtype,

--- a/intake/container/dataframe.py
+++ b/intake/container/dataframe.py
@@ -3,21 +3,17 @@ from .base import RemoteSource, get_partition
 
 
 class RemoteDataFrame(RemoteSource):
+    """Dataframe on an Intake server"""
 
     name = 'remote_dataframe'
     container = 'dataframe'
 
     def __init__(self, url, headers, **kwargs):
-        import pickle
         super(RemoteDataFrame, self).__init__(url, headers, **kwargs)
         self.npartitions = kwargs['npartitions']
         self.shape = tuple(kwargs['shape'])
         self.metadata = kwargs['metadata']
-        d = kwargs['dtype']
-        if isinstance(d, bytes):
-            self.dtype = pickle.loads(d)
-        else:
-            self.dtype = d
+        self.dtype = kwargs['dtype']
         self._schema = Schema(npartitions=self.npartitions,
                               extra_metadata=self.metadata,
                               dtype=self.dtype,

--- a/intake/container/ndarray.py
+++ b/intake/container/ndarray.py
@@ -1,7 +1,7 @@
-import msgpack
-import numpy as np
-import msgpack_numpy
+from .base import RemoteSource
 
 
-class NdArray():
-    pass
+class RemoteArray(RemoteSource):
+    # TODO
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError

--- a/intake/container/semistructured.py
+++ b/intake/container/semistructured.py
@@ -3,6 +3,7 @@ from intake.source.base import Schema
 
 
 class RemoteSequenceSource(RemoteSource):
+    """Sequence-of-things source on an Intake server"""
     name = 'remote_sequence'
     container = 'python'
 

--- a/intake/container/semistructured.py
+++ b/intake/container/semistructured.py
@@ -33,9 +33,11 @@ class RemoteSequenceSource(RemoteSource):
         return self.parts[i].compute()
 
     def read(self):
+        self._load_metadata()
         return self.bag.compute()
 
     def to_dask(self):
+        self._load_metadata()
         return self.bag
 
     def _close(self):

--- a/intake/source/__init__.py
+++ b/intake/source/__init__.py
@@ -1,1 +1,2 @@
+# The registry is the mapping of plugin name (aka driver) to DataSource class
 registry = {}

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -22,9 +22,10 @@ class Schema(object):
 class DataSource(object):
     name = None
     version = None
-    container = 'python'
+    container = None
     partition_access = False
     datashape = None
+    description = None
 
     def __new__(cls, *args, **kwargs):
         o = object.__new__(cls)
@@ -49,9 +50,7 @@ class DataSource(object):
     def __setstate__(self, state):
         self.__init__(*state['args'], **state['kwargs'])
 
-    def __init__(self, container, description=None, metadata=None):
-        self.container = container
-        self.description = description
+    def __init__(self, metadata=None):
         self.metadata = metadata or {}
         self.datashape = None
         self.dtype = None

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -89,8 +89,11 @@ class DataSource(object):
     def yaml(self):
         """Return YAML representation of this data-source"""
         import ruamel.yaml
+        import inspect
         kwargs = self._captured_init_kwargs.copy()
-        meta = kwargs.pop('metadata')
+        meta = kwargs.pop('metadata', self.metadata) or {}
+        kwargs.update(dict(zip(inspect.signature(self.__init__).parameters,
+                      self._captured_init_args)))
         data = {self.name: {
             'driver': self.__class__.name,
             'description': self.description,

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -88,7 +88,7 @@ class DataSource(object):
 
     def yaml(self):
         """Return YAML representation of this data-source"""
-        import ruamel.yaml
+        import ruamel_yaml
         import inspect
         kwargs = self._captured_init_kwargs.copy()
         meta = kwargs.pop('metadata', self.metadata) or {}
@@ -101,7 +101,7 @@ class DataSource(object):
             'metadata': meta,
             'args': kwargs
         }}
-        return ruamel.yaml.dump(data, default_flow_style=False)
+        return ruamel_yaml.dump(data, default_flow_style=False)
 
     def discover(self):
         """Open resource and populate the source attributes."""

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -92,6 +92,7 @@ class DataSource(object):
         import inspect
         kwargs = self._captured_init_kwargs.copy()
         meta = kwargs.pop('metadata', self.metadata) or {}
+        # TODO: inspect.signature is py3 only
         kwargs.update(dict(zip(inspect.signature(self.__init__).parameters,
                       self._captured_init_args)))
         data = {self.name: {

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -159,7 +159,7 @@ class DataSource(object):
             from hvplot import hvPlot
         except ImportError:
             raise ImportError("The intake plotting API requires hvplot."
-                              "holoplot may be installed with:\n\n"
+                              "hvplot may be installed with:\n\n"
                               "`conda install -c pyviz hvplot` or "
                               "`pip install hvplot`.")
         metadata = self.metadata.get('plot', {})

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -86,6 +86,19 @@ class DataSource(object):
             self.npartitions = self._schema.npartitions
             self.metadata.update(self._schema.extra_metadata)
 
+    def yaml(self):
+        """Return YAML representation of this data-source"""
+        import ruamel.yaml
+        kwargs = self._captured_init_kwargs.copy()
+        meta = kwargs.pop('metadata')
+        data = {self.name: {
+            'driver': self.__class__.name,
+            'description': self.description,
+            'metadata': meta,
+            'args': kwargs
+        }}
+        return ruamel.yaml.dump(data, default_flow_style=False)
+
     def discover(self):
         """Open resource and populate the source attributes."""
         self._load_metadata()

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -32,8 +32,7 @@ class CSVSource(base.DataSource):
         self._csv_kwargs = csv_kwargs or {}
         self._dataframe = None
 
-        super(CSVSource, self).__init__(container='dataframe',
-                                        metadata=metadata)
+        super(CSVSource, self).__init__(metadata=metadata)
 
     def _get_schema(self):
         import dask.dataframe

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -42,10 +42,11 @@ class CSVSource(base.DataSource):
                 self._urlpath, storage_options=self._storage_options,
                 **self._csv_kwargs)
 
-        dtypes = self._dataframe._meta
+        dtypes = self._dataframe._meta.dtypes.to_dict()
+        dtypes = {n: str(t) for (n, t) in dtypes.items()}
         return base.Schema(datashape=None,
                            dtype=dtypes,
-                           shape=(None, len(dtypes.columns)),
+                           shape=(None, len(dtypes)),
                            npartitions=self._dataframe.npartitions,
                            extra_metadata={})
 

--- a/intake/source/tests/plugin_searchpath/collision_foo/__init__.py
+++ b/intake/source/tests/plugin_searchpath/collision_foo/__init__.py
@@ -6,6 +6,3 @@ class FooPlugin(DataSource):
     version = '0.1'
     container = 'dataframe'
     partition_access = False
-
-    def __init__(self, **kwargs):
-        pass

--- a/intake/source/tests/plugin_searchpath/collision_foo2/__init__.py
+++ b/intake/source/tests/plugin_searchpath/collision_foo2/__init__.py
@@ -6,6 +6,3 @@ class FooPlugin(DataSource):
     version = '0.1'
     container = 'dataframe'
     partition_access = False
-
-    def __init__(self, **kwargs):
-        pass

--- a/intake/source/tests/test_base.py
+++ b/intake/source/tests/test_base.py
@@ -10,7 +10,7 @@ from .. import base
 
 def test_datasource_base_method_exceptions():
     # Unimplemented methods should raise exceptions
-    d = base.DataSource(container='dataframe')
+    d = base.DataSource()
 
     for (method_name, args) in [('_get_schema', []),
                                 ('_get_partition', [1]),
@@ -26,16 +26,19 @@ def test_datasource_base_context_manager():
     # enters the context manager (which loads the schema)
 
     with pytest.raises(Exception) as except_info:
-        with base.DataSource(container='dataframe'):
+        with base.DataSource():
             pass
     assert '_get_schema' in str(except_info.value)
 
 
 class MockDataSourceDataFrame(base.DataSource):
-    '''Mock Data Source subclass that returns dataframe containers
+    """Mock Data Source subclass that returns dataframe containers
 
     Used to verify that the base DataSource class logic works for dataframes.
-    '''
+    """
+
+    container = 'dataframe'
+
     def __init__(self, a, b):
         self.a = a
         self.b = b
@@ -43,7 +46,6 @@ class MockDataSourceDataFrame(base.DataSource):
         self.call_count = defaultdict(lambda: 0)
 
         super(MockDataSourceDataFrame, self).__init__(
-            container='dataframe',
             metadata=dict(a=1, b=2)
         )
         self.npartitions = 2
@@ -195,10 +197,11 @@ def test_datasource_pickle(source_dataframe):
 
 
 class MockDataSourcePython(base.DataSource):
-    '''Mock Data Source subclass that returns Python list containers
+    """Mock Data Source subclass that returns Python list containers
 
     Used to verify that the base DataSource class logic works for Python lists.
-    '''
+    """
+    container = 'python'
 
     def __init__(self, a, b):
         self.a = a
@@ -207,7 +210,6 @@ class MockDataSourcePython(base.DataSource):
         self.call_count = defaultdict(lambda: 0)
 
         super(MockDataSourcePython, self).__init__(
-            container='python',
             metadata=dict(a=1, b=2)
         )
         self.npartitions = 2

--- a/intake/source/tests/test_base.py
+++ b/intake/source/tests/test_base.py
@@ -38,6 +38,7 @@ class MockDataSourceDataFrame(base.DataSource):
     """
 
     container = 'dataframe'
+    name = 'mock'
 
     def __init__(self, a, b):
         self.a = a
@@ -202,6 +203,7 @@ class MockDataSourcePython(base.DataSource):
     Used to verify that the base DataSource class logic works for Python lists.
     """
     container = 'python'
+    name = 'mock'
 
     def __init__(self, a, b):
         self.a = a
@@ -293,3 +295,10 @@ def test_datasource_python_to_dask(source_python):
     assert db == [{'x': 'foo', 'y': 'bar'},
                   {'x': 'foo', 'y': 'bar', 'z': 'baz'},
                   {'x': 1}, {}]
+
+
+def test_yaml_method(source_python):
+    out = source_python.yaml()
+    assert 'mock' in out  # the "driver"
+    assert 'metadata' in out
+    assert 'a: 1' in out

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -45,8 +45,8 @@ def test_open(data_filenames):
 def test_discover(sample1_datasource):
     info = sample1_datasource.discover()
 
-    assert info['dtype'].dtypes.to_dict() == {'name': 'O', 'score': 'f8',
-                                              'rank': 'i8'}
+    assert info['dtype'] == {'name': 'object', 'score': 'float64',
+                             'rank': 'int64'}
     # Do not know length without parsing CSV
     assert info['shape'] == (None, 3)
     assert info['npartitions'] == 1

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -92,6 +92,14 @@ def test_to_dask(sample1_datasource, data_filenames):
     assert expected_df.equals(df)
 
 
+def test_plot(sample1_datasource):
+    pytest.importorskip('hvplot')
+    import holoviews
+
+    p = sample1_datasource.plot()
+    assert isinstance(sample1_datasource.plot(), holoviews.NdOverlay)
+
+
 def test_close(sample1_datasource, data_filenames):
     sample1_datasource.close()
     # Can reopen after close

--- a/intake/source/tests/test_text.py
+++ b/intake/source/tests/test_text.py
@@ -1,0 +1,12 @@
+import glob
+from intake.source.textfiles import TextFilesSource
+
+
+def test_textfiles():
+    t = TextFilesSource('./*.py')
+    t.discover()
+    assert t.npartitions == len(glob.glob('./*.py'))
+    assert t._get_partition(0) == t.to_dask().to_delayed()[0].compute()
+    out = t.read()
+    assert isinstance(out, list)
+    assert isinstance(out[0], str)

--- a/intake/source/tests/test_text.py
+++ b/intake/source/tests/test_text.py
@@ -1,12 +1,16 @@
 import glob
+import os
 from intake.source.textfiles import TextFilesSource
 
 
-def test_textfiles():
-    t = TextFilesSource('./*.py')
+def test_textfiles(tmpdir):
+    open(os.path.join(tmpdir, '1.txt'), 'wt').write('hello\nworld')
+    open(os.path.join(tmpdir, '2.txt'), 'wt').write('hello\nworld')
+    path = os.path.join(tmpdir, '*.txt')
+    t = TextFilesSource(path)
     t.discover()
-    assert t.npartitions == len(glob.glob('./*.py'))
+    assert t.npartitions == len(glob.glob(path))
     assert t._get_partition(0) == t.to_dask().to_delayed()[0].compute()
     out = t.read()
     assert isinstance(out, list)
-    assert isinstance(out[0], str)
+    assert out[0] == 'hello\n'

--- a/intake/source/textfiles.py
+++ b/intake/source/textfiles.py
@@ -1,0 +1,49 @@
+from . import base
+
+
+class TextFilesSource(base.DataSource):
+    """Read textfiles as sequence of lines
+    """
+    name = 'textfiles'
+    version = '0.0.1'
+    container = 'python'
+    partition_access = True
+
+    def __init__(self, urlpath, metadata=None,
+                 storage_options=None):
+        self._urlpath = urlpath
+        self._storage_options = storage_options or {}
+        self._dataframe = None
+        self._files = None
+
+        super(TextFilesSource, self).__init__(metadata=metadata)
+
+    def _get_schema(self):
+        from dask.bytes import open_files
+        if self._files is None:
+            self._files = open_files(self._urlpath, mode='rt',
+                                     **self._storage_options)
+            self.npartitions = len(self._files)
+        return base.Schema(datashape=None,
+                           dtype=None,
+                           shape=(None, ),
+                           npartitions=self.npartitions,
+                           extra_metadata=self.metadata)
+
+    def _get_partition(self, i):
+        return get_file(self._files[i])
+
+    def read(self):
+        self._get_schema()
+        return self.to_dask().compute()
+
+    def to_dask(self):
+        import dask.bag as db
+        from dask import delayed
+        dfile = delayed(get_file)
+        return db.from_delayed([dfile(f) for f in self._files])
+
+
+def get_file(f):
+    with f as f:
+        return list(f)

--- a/intake/source/textfiles.py
+++ b/intake/source/textfiles.py
@@ -3,6 +3,10 @@ from . import base
 
 class TextFilesSource(base.DataSource):
     """Read textfiles as sequence of lines
+
+    Takes a set of files, and returns an iterator over the text in each of them.
+    The files can be local or remote. Extra parameters for encoding, etc.,
+    go into ``storage_options``.
     """
     name = 'textfiles'
     version = '0.0.1'
@@ -11,6 +15,18 @@ class TextFilesSource(base.DataSource):
 
     def __init__(self, urlpath, metadata=None,
                  storage_options=None):
+        """
+
+        Parameters
+        ----------
+        urlpath : str or list(str)
+            Target files. Can be a glob-path (with "*") and include protocol
+            specified (e.g., "s3://"). Can also be a list of absolute paths.
+        storage_options: dict
+            Options to pass to the file reader backend, including text-specific
+            encoding arguments, and parameters specific to the remote
+            file-system driver, if using.
+        """
         self._urlpath = urlpath
         self._storage_options = storage_options or {}
         self._dataframe = None

--- a/intake/source/textfiles.py
+++ b/intake/source/textfiles.py
@@ -61,5 +61,6 @@ class TextFilesSource(base.DataSource):
 
 
 def get_file(f):
+    """Serializable function to take an OpenFile object and read lines"""
     with f as f:
         return list(f)

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -42,3 +42,13 @@ def test_user_catalog(user_catalog):
     cat = intake.load_combo_catalog()
     time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
+
+
+def test_bad_open():
+    with pytest.raises(ValueError):
+        intake.open_catalog(None, driver='unknown')
+
+
+def test_output_notebook():
+    pytest.importorskip('hvplot')
+    intake.output_notebook()


### PR DESCRIPTION
builds on #120 

Also adds `yaml()` method of data sources, to get back a representation of sources from `open_*` or data-source factories.