### PR TITLE
Allow for cache_path="catdir" to put cached files alongside cats

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -208,8 +208,12 @@ Example:
     args:
       urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'
 
-The ``cache_dir`` defaults to ``~/.intake/cache``, and can be specified in the intake configuration file or ``INTAKE_CACHE_DIR`` 
-environment variable. Explicit glob-strings may be used for the urlpath argument.
+The ``cache_dir`` defaults to ``~/.intake/cache``, and can be specified in the intake configuration
+file or ``INTAKE_CACHE_DIR``
+environment variable, or at runtime using the ``"cache_dir"`` key of the configuration.
+The special value ``"catdir"`` implies that cached files will appear in the same directory as the
+catalog file in which the data source is defined, within a directory named "intake_cache". These will
+not appear in the cache usage reported by the CLI.
 
 Caching can be disabled at runtime for all sources regardless of the catalog specificiation::
 

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -182,9 +182,10 @@ class LocalCatalogEntry(CatalogEntry):
 
         self._open_args['cache'] = self._cache
         open_args = expand_templates(self._open_args, params)
-        if self._metadata is not None:
-            self._metadata['cache'] = open_args.pop('cache', [])
-        open_args['metadata'] = self._metadata
+        md = self._metadata.copy() if self._metadata is not None else {}
+        md['cache'] = open_args.pop('cache', [])
+        md['catalog_dir'] = self._catalog_dir
+        open_args['metadata'] = md
 
         return open_args
 

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -150,7 +150,7 @@ class LocalCatalogEntry(CatalogEntry):
         self._open_args = args
         self._cache = cache
         self._user_parameters = parameters
-        self._metadata = metadata
+        self._metadata = metadata or {}
         self._catalog_dir = catalog_dir
         self._plugin = global_registry[driver]
         super(LocalCatalogEntry, self).__init__(
@@ -182,8 +182,8 @@ class LocalCatalogEntry(CatalogEntry):
 
         self._open_args['cache'] = self._cache
         open_args = expand_templates(self._open_args, params)
+        self._metadata['cache'] = open_args.pop('cache', [])
         md = self._metadata.copy() if self._metadata is not None else {}
-        md['cache'] = open_args.pop('cache', [])
         md['catalog_dir'] = self._catalog_dir
         open_args['metadata'] = md
 

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -49,7 +49,9 @@ def test_local_catalog(catalog1):
         'direct_access': 'allow'
     }
     assert catalog1['entry1'].get().container == 'dataframe'
-    assert catalog1['entry1'].get().metadata == dict(foo='bar', bar=[1, 2, 3], cache=[])
+    md = catalog1['entry1'].get().metadata
+    md.pop('catalog_dir')
+    assert md == dict(foo='bar', bar=[1, 2, 3], cache=[])
 
     # Use default parameters
     assert catalog1['entry1_part'].get().container == 'dataframe'
@@ -249,6 +251,7 @@ def test_union_catalog():
     desc_open = union_cat.entry1_part.describe_open()
     assert desc_open['args']['urlpath'].endswith('entry1_1.csv')
     del desc_open['args']['urlpath']  # Full path will be system dependent
+    desc_open['args']['metadata'].pop('catalog_dir')
     assert desc_open == {
         'args': {'metadata': {'bar': [2, 4, 6], 'cache': [], 'foo': 'baz'}},
         'description': 'entry1 part',
@@ -259,7 +262,9 @@ def test_union_catalog():
 
     # Implied creation of data source
     assert union_cat.entry1.container == 'dataframe'
-    assert union_cat.entry1.metadata == dict(foo='bar', bar=[1, 2, 3], cache=[])
+    md = union_cat.entry1.metadata
+    md.pop('catalog_dir')
+    assert md == dict(foo='bar', bar=[1, 2, 3], cache=[])
 
     # Use default parameters in explict creation of data source
     assert union_cat.entry1_part().container == 'dataframe'

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -87,7 +87,9 @@ def test_read(intake_server):
     assert info['npartitions'] == 2
     assert info['shape'] == (None, 3)  # Do not know CSV size ahead of time
 
-    assert d.metadata == dict(foo='bar', bar=[1, 2, 3], cache=[])
+    md = d.metadata.copy()
+    md.pop('catalog_dir', None)
+    assert md == dict(foo='bar', bar=[1, 2, 3], cache=[])
 
     df = d.read()
 
@@ -110,9 +112,13 @@ def test_read_direct(intake_server):
                              in meta.dtypes.to_dict().items()}
     assert info['npartitions'] == 1
     assert info['shape'] == (None, 3)  # Do not know CSV size ahead of time
-    assert info['metadata'] == {'bar': [2, 4, 6], 'foo': 'baz', 'cache': []}
+    md = info['metadata'].copy()
+    md.pop('catalog_dir', None)
+    assert md == {'bar': [2, 4, 6], 'foo': 'baz', 'cache': []}
 
-    assert d.metadata == dict(foo='baz', bar=[2, 4, 6], cache=[])
+    md = d.metadata.copy()
+    md.pop('catalog_dir', None)
+    assert md == dict(foo='baz', bar=[2, 4, 6], cache=[])
     assert d.description == 'entry1 part'
     df = d.read()
 

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -98,7 +98,9 @@ class TestServerV1Source(TestServerV1Base):
         actual_dtype = resp_msg['dtype']
         self.assertEqual(expected_dtype, actual_dtype)
         self.assertEqual(resp_msg['npartitions'], 2)
-        self.assertEqual(resp_msg['metadata'], dict(foo='bar', bar=[1, 2, 3], cache=[]))
+        md = resp_msg['metadata']
+        md.pop('catalog_dir', None)
+        self.assertEqual(md, dict(foo='bar', bar=[1, 2, 3], cache=[]))
 
         self.assert_(isinstance(resp_msg['source_id'], str))
 
@@ -111,7 +113,9 @@ class TestServerV1Source(TestServerV1Base):
         args = resp_msg['args']
         self.assertEquals(set(args.keys()), set(['urlpath', 'metadata']))
         self.assert_(args['urlpath'].endswith('/entry1_2.csv'))
-        self.assertEquals(args['metadata'], dict(foo='baz', bar=[2, 4, 6], cache=[]))
+        md = args['metadata']
+        md.pop('catalog_dir', None)
+        self.assertEquals(md, dict(foo='baz', bar=[2, 4, 6], cache=[]))
         self.assertEqual(resp_msg['description'], 'entry1 part')
 
     def test_read_part_compressed(self):

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -80,7 +80,9 @@ class DataSource(object):
         self.metadata = metadata or {}
         if isinstance(self.metadata, dict):
             storage_options = self._captured_init_kwargs.get('storage_options', {})
-            self.cache = make_caches(self.name, self.metadata.get('cache'), storage_options)
+            self.cache = make_caches(self.name, self.metadata.get('cache'),
+                                     catdir=self.metadata.get('catalog_dir', None),
+                                     storage_options=storage_options)
         self.datashape = None
         self.dtype = None
         self.shape = None

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -44,7 +44,8 @@ class BaseCache(object):
     # download block size in bytes
     blocksize = 5000000
 
-    def __init__(self, driver, spec, cache_dir=None, storage_options={}):
+    def __init__(self, driver, spec, catdir=None, cache_dir=None,
+                 storage_options={}):
         """
         Parameters:
         -----------
@@ -52,11 +53,21 @@ class BaseCache(object):
             Name of the plugin that can load catalog entry
         spec: list
             Specification for caching the data source.
+        cache_dir: str or None
+            Explicit location of cache root directory
+        catdir: str or None
+            Directory containing the catalog from which this spec was made
         """
         self._driver = driver
         self._spec = spec
-        self._cache_dir = cache_dir or conf['cache_dir']
-                             
+        cd = cache_dir or spec.get('cache_dir', conf['cache_dir'])
+        if cd == 'catdir':
+            if catdir is None:
+                raise TypeError('cache_dir="catdir" only allowed when loaded'
+                                'from a catalog file.')
+            cd = catdir
+        self._cache_dir = cd
+
         self._storage_options = storage_options
         self._metadata = CacheMetadata()
     
@@ -455,7 +466,7 @@ registry = {
 }
 
 
-def make_caches(driver, specs, storage_options):
+def make_caches(driver, specs, catdir=None, cache_dir=None, storage_options={}):
     """
     Creates Cache objects from the cache_specs provided in the catalog yaml file.
     
@@ -469,5 +480,6 @@ def make_caches(driver, specs, storage_options):
     if specs is None:
         return []
     return [registry.get(spec['type'], FileCache)(
-                driver, spec, storage_options=storage_options)
-            for spec in specs]
+        driver, spec, catdir=catdir, cache_dir=cache_dir,
+        storage_options=storage_options)
+        for spec in specs]

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -60,12 +60,12 @@ class BaseCache(object):
         """
         self._driver = driver
         self._spec = spec
-        cd = cache_dir or spec.get('cache_dir', conf['cache_dir'])
+        cd = cache_dir or conf['cache_dir']
         if cd == 'catdir':
             if catdir is None:
                 raise TypeError('cache_dir="catdir" only allowed when loaded'
                                 'from a catalog file.')
-            cd = catdir
+            cd = os.path.join(catdir, 'intake_cache')
         self._cache_dir = cd
 
         self._storage_options = storage_options


### PR DESCRIPTION
Fixes #151 

If `cache_dir="catdir"`, resultant directory will be placed under the directory containing the catalog file. 
