### PR TITLE
Raise is attempt to open cat file which cannot be read

### DIFF
--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -277,6 +277,11 @@ def test_empty_catalog():
     assert list(cat) == []
 
 
+def test_nonexistent_error():
+    with pytest.raises(IOError):
+        local.YAMLFileCatalog('nonexistent')
+
+
 def test_duplicate_data_sources():
     path = os.path.dirname(__file__)
     uri = os.path.join(path, 'catalog_dup_sources.yml')


### PR DESCRIPTION
Does not affect reading a *directory*, which will still return an
empty cat if does not exist, and will update automatically as before

Fixes #159