### PR TITLE
Adding a pattern mixin and allow path_as_pattern to be a string

### DIFF
--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -37,6 +37,12 @@ def sample_list_datasource(data_filenames):
     return csv.CSVSource([data_filenames['sample2_1'], data_filenames['sample2_2']])
 
 @pytest.fixture
+def sample_list_datasource_with_path_as_pattern_str(data_filenames):
+    return csv.CSVSource(
+        [data_filenames['sample2_1'], data_filenames['sample2_2']],
+        path_as_pattern='sample{num:d}_{dup:d}.csv')
+
+@pytest.fixture
 def sample_pattern_datasource_with_cache(data_filenames):
     metadata = {'cache': [{'argkey': 'urlpath',
                            'regex': os.path.dirname(__file__),
@@ -120,6 +126,10 @@ def test_read_pattern(sample_pattern_datasource):
 
 def test_read_pattern_with_cache(sample_pattern_datasource_with_cache):
     check_read_pattern_output(sample_pattern_datasource_with_cache)
+
+
+def test_read_pattern_with_path_as_pattern_str(sample_list_datasource_with_path_as_pattern_str):
+    check_read_pattern_output(sample_list_datasource_with_path_as_pattern_str)
 
 
 def test_read_partition(sample2_datasource, data_filenames):

--- a/intake/source/tests/test_utils.py
+++ b/intake/source/tests/test_utils.py
@@ -19,6 +19,8 @@ def test_path_to_glob(pattern, expected):
 
 @pytest.mark.parametrize('pattern,resolved,expected', [
     ('*.csv', 'apple.csv', {}),
+    ('{}.csv', 'apple.csv', {}),
+    ('{fruit}.{}', 'apple.csv', {'fruit': 'apple'}),
     ('{num:d}.csv', 'k.csv', {'num': 'k'}),
     ('{year:d}/{month:d}/{day:d}.csv', '2016/2/01.csv',
     {'year': 2016, 'month': 2, 'day': 1}),

--- a/intake/source/utils.py
+++ b/intake/source/utils.py
@@ -96,7 +96,7 @@ def reverse_formats(format_string, resolved_strings):
     fmt = Formatter()
 
     # get the fields from the format_string
-    field_names = [i[1] for i in fmt.parse(format_string) if i[1] is not None]
+    field_names = [i[1] for i in fmt.parse(format_string) if i[1]]
 
     # itialize the args dict with an empty dict for each field
     args = {field_name: [] for field_name in field_names}
@@ -165,7 +165,7 @@ def reverse_format(format_string, resolved_string):
     bits = _get_parts_of_format_string(resolved_string, literal_texts, format_specs)
 
     for i, (field_name, format_spec) in enumerate(zip(field_names, format_specs)):
-        if field_name is not None:
+        if field_name:
             try:
                 if format_spec.startswith('%'):
                     args[field_name] = datetime.strptime(bits[i], format_spec)


### PR DESCRIPTION
I made some improvements to allow the passing of lists of paths with a separate pattern that matches them all. This allows use with https for instance. 

Blocks https://github.com/ContinuumIO/intake-xarray/pull/17