### PR TITLE
Add INTAKE_PATH default catalog loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   if [ -n "$TRAVIS_TAG" ]; then
       # If tagged git version, upload package to main channel
       anaconda -t ${ANACONDA_TOKEN} upload -u intake --force `conda build --output ./conda`
-  else
+  elif ! [ -n "$TRAVIS_PULL_REQUEST" ]; then
       # Otherwise upload package to dev channel
       anaconda -t ${ANACONDA_TOKEN} upload -u intake --label dev --force `conda build --output ./conda`
   fi

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -154,7 +154,7 @@ installed in user-specific location.
 
 Adding Data Source Packages using the Intake path
 -------------------------------------------------
-Intake checks the environment variable `INTAKE_PATH` for a colon separated list of paths to search for catalog files.
+Intake checks the environment variable `INTAKE_PATH` for a colon separated list of paths (semicolon on windows) to search for catalog files.
 When you import ``intake`` we will see data from catalog files in the path appear as part of a global catalog
 called ``intake.cat``.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -151,6 +151,14 @@ Conda installs the catalog file in this package to ``$CONDA_PREFIX/share/intake/
 The global catalog is a union of all catalogs installed in the conda/virtualenv environment and also any catalogs
 installed in user-specific location.
 
+
+Adding Data Source Packages using the Intake path
+-------------------------------------------------
+Intake checks the environment variable `INTAKE_PATH` for a colon separated list of paths to search for catalog files.
+When you import ``intake`` we will see data from catalog files in the path appear as part of a global catalog
+called ``intake.cat``.
+
+
 Using the GUI
 -------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -154,8 +154,8 @@ installed in user-specific location.
 
 Adding Data Source Packages using the Intake path
 -------------------------------------------------
-Intake checks the environment variable `INTAKE_PATH` for a colon separated list of paths (semicolon on windows) to search for catalog files.
-When you import ``intake`` we will see data from catalog files in the path appear as part of a global catalog
+Intake checks the Intake config file for `catalog_path` or the environment variable `INTAKE_PATH` for a colon separated list of paths (semicolon on windows) to search for catalog files.
+When you import ``intake`` we will see all entries from all of the catalogues referenced as part of a global catalog
 called ``intake.cat``.
 
 

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -98,8 +98,10 @@ def load_combo_catalog():
         cat_dirs.append(global_dir + '/*.yaml')
         cat_dirs.append(global_dir + '/*.yml')
     for path_dir in conf.get('catalog_path', []):
-        if os.path.isdir(path_dir):
+        if os.path.isdir(path_dir) and path_dir != '':
             cat_dirs.append(path_dir + '/*.yaml')
             cat_dirs.append(path_dir + '/*.yml')
+
+    print(cat_dirs)
 
     return YAMLFilesCatalog(cat_dirs, name='builtin')

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 
+from intake.config import conf
 from .local import YAMLFilesCatalog, Catalog
 
 
@@ -32,7 +33,6 @@ def load_global_catalog():
 
 CONDA_VAR = 'CONDA_PREFIX'
 VIRTUALENV_VAR = 'VIRTUAL_ENV'
-INTAKE_PATH_VAR = 'INTAKE_PATH'
 
 
 def conda_prefix():
@@ -88,7 +88,7 @@ def global_data_dir():
 def intake_path_dirs():
     """Return a list of directories from the intake path."""
     separator = ';' if os.name == 'nt' else ':'
-    return os.environ.get(INTAKE_PATH_VAR, '').split(separator)
+    return conf.get('catalog_path', '').split(separator)
 
 
 def load_combo_catalog():

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -85,12 +85,6 @@ def global_data_dir():
         return appdirs.site_data_dir(appname='intake', appauthor='intake')
 
 
-def intake_path_dirs():
-    """Return a list of directories from the intake path."""
-    separator = ';' if os.name == 'nt' else ':'
-    return conf.get('catalog_path', '').split(separator)
-
-
 def load_combo_catalog():
     """Load a union of the user and global catalogs for convenience"""
     user_dir = user_data_dir()
@@ -103,7 +97,7 @@ def load_combo_catalog():
     if os.path.isdir(global_dir):
         cat_dirs.append(global_dir + '/*.yaml')
         cat_dirs.append(global_dir + '/*.yml')
-    for path_dir in intake_path_dirs():
+    for path_dir in conf.get('catalog_path', []):
         if os.path.isdir(path_dir):
             cat_dirs.append(path_dir + '/*.yaml')
             cat_dirs.append(path_dir + '/*.yml')

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -87,10 +87,7 @@ def global_data_dir():
 
 def intake_path_dirs():
     """Return a list of directories from the intake path."""
-    if os.name == 'nt':
-        separator = ';'
-    else:
-        separator = ':'
+    separator = ';' if os.name == 'nt' else ':'
     return os.environ.get(INTAKE_PATH_VAR, '').split(separator)
 
 

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -87,7 +87,11 @@ def global_data_dir():
 
 def intake_path_dirs():
     """Return a list of directories from the intake path."""
-    return os.environ.get(INTAKE_PATH_VAR, '').split(':')
+    if os.name == 'nt':
+        separator = ';'
+    else:
+        separator = ':'
+    return os.environ.get(INTAKE_PATH_VAR, '').split(separator)
 
 
 def load_combo_catalog():

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -32,6 +32,7 @@ def load_global_catalog():
 
 CONDA_VAR = 'CONDA_PREFIX'
 VIRTUALENV_VAR = 'VIRTUAL_ENV'
+INTAKE_PATH_VAR = 'INTAKE_PATH'
 
 
 def conda_prefix():
@@ -76,12 +77,17 @@ def global_data_dir():
     elif which('conda'):
         # conda exists but is not activated
         prefix = conda_prefix()
-    
+
     if prefix:
         # conda and virtualenv use Linux-style directory pattern
         return os.path.join(prefix, 'share', 'intake')
     else:
         return appdirs.site_data_dir(appname='intake', appauthor='intake')
+
+
+def intake_path_dirs():
+    """Return a list of directories from the intake path."""
+    return os.environ.get(INTAKE_PATH_VAR, '').split(':')
 
 
 def load_combo_catalog():
@@ -96,5 +102,9 @@ def load_combo_catalog():
     if os.path.isdir(global_dir):
         cat_dirs.append(global_dir + '/*.yaml')
         cat_dirs.append(global_dir + '/*.yml')
+    for path_dir in intake_path_dirs():
+        if os.path.isdir(path_dir):
+            cat_dirs.append(path_dir + '/*.yaml')
+            cat_dirs.append(path_dir + '/*.yml')
 
     return YAMLFilesCatalog(cat_dirs, name='builtin')

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -102,6 +102,4 @@ def load_combo_catalog():
             cat_dirs.append(path_dir + '/*.yaml')
             cat_dirs.append(path_dir + '/*.yml')
 
-    print(cat_dirs)
-
     return YAMLFilesCatalog(cat_dirs, name='builtin')

--- a/intake/config.py
+++ b/intake/config.py
@@ -61,6 +61,12 @@ def load_conf(fn=None):
             conf.update(yaml.load(f))
 
 
+def intake_path_dirs(path):
+    """Return a list of directories from the intake path."""
+    separator = ';' if os.name == 'nt' else ':'
+    return path.split(separator)
+
+
 reset_conf()
 load_conf(conffile)
 # environment variables take precedence over conf file
@@ -75,7 +81,7 @@ if 'INTAKE_CACHE_PROGRESS' in os.environ:
 if 'INTAKE_LOG_LEVEL' in os.environ:
     conf['logging'] = os.environ['INTAKE_LOG_LEVEL']
 if 'INTAKE_PATH' in os.environ:
-    conf['catalog_path'] = os.environ['INTAKE_PATH']
+    conf['catalog_path'] = intake_path_dirs(os.environ['INTAKE_PATH'])
 logger.setLevel(conf['logging'])
 ch = logging.StreamHandler()
 formatter = logging.Formatter('%(asctime)s %(name)s:%(levelname)s, %(message)s')

--- a/intake/config.py
+++ b/intake/config.py
@@ -74,6 +74,8 @@ if 'INTAKE_CACHE_PROGRESS' in os.environ:
                                       ].lower() == 'true'
 if 'INTAKE_LOG_LEVEL' in os.environ:
     conf['logging'] = os.environ['INTAKE_LOG_LEVEL']
+if 'INTAKE_PATH' in os.environ:
+    conf['catalog_path'] = os.environ['INTAKE_PATH']
 logger.setLevel(conf['logging'])
 ch = logging.StreamHandler()
 formatter = logging.Formatter('%(asctime)s %(name)s:%(levelname)s, %(message)s')

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -57,7 +57,7 @@ def test_user_catalog(user_catalog):
 
 
 def test_path_catalog(tmp_path_catalog):
-    os.environ['INTAKE_PATH'] = os.path.join(tempfile.gettempdir(), 'intake')
+    intake.config.conf['catalog_path'] = os.path.join(tempfile.gettempdir(), 'intake')
     cat = intake.load_combo_catalog()
     time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -52,12 +52,14 @@ def test_default_catalogs():
 
 def test_user_catalog(user_catalog):
     cat = intake.load_combo_catalog()
+    time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
 
 
 def test_path_catalog(tmp_path_catalog):
     intake.config.conf['catalog_path'] = os.path.join(tempfile.gettempdir(), 'intake')
     cat = intake.load_combo_catalog()
+    time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
 
 

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -33,8 +33,12 @@ def user_catalog():
 
 @pytest.fixture
 def tmp_path_catalog():
-    target_catalog = copy_test_file('catalog1.yml',
-                                    os.path.join(tempfile.gettempdir(), 'intake'))
+    tmp_path = os.path.join(tempfile.gettempdir(), 'intake')
+    try:
+        os.makedirs(tmp_path)
+    except:
+        pass
+    target_catalog = copy_test_file('catalog1.yml', tmp_path)
     yield target_catalog
     # Remove the file, but not the directory (because there might be other
     # files already there)
@@ -57,7 +61,7 @@ def test_user_catalog(user_catalog):
 
 
 def test_path_catalog(tmp_path_catalog):
-    intake.config.conf['catalog_path'] = os.path.join(tempfile.gettempdir(), 'intake')
+    intake.config.conf['catalog_path'] = [os.path.join(tempfile.gettempdir(), 'intake')]
     cat = intake.load_combo_catalog()
     time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -52,14 +52,12 @@ def test_default_catalogs():
 
 def test_user_catalog(user_catalog):
     cat = intake.load_combo_catalog()
-    time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
 
 
 def test_path_catalog(tmp_path_catalog):
     intake.config.conf['catalog_path'] = os.path.join(tempfile.gettempdir(), 'intake')
     cat = intake.load_combo_catalog()
-    time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
 
 

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -65,6 +65,7 @@ def test_path_catalog(tmp_path_catalog):
     cat = intake.load_combo_catalog()
     time.sleep(2) # wait 2 seconds for catalog to refresh
     assert set(cat) >= set(['ex1', 'ex2'])
+    del intake.config.conf['catalog_path']
 
 
 def test_bad_open():


### PR DESCRIPTION
Closes #167.

This PR updates the default catalog loader to check for any directories specified by the `INTAKE_PATH` environment variable. This behaves like a regular path where each directory should be colon separated. If each directory exists it will be included in the loading of default catalog files.