### PR TITLE
Put ipywidgets dependency in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six
 tornado >= 4.5.1
 dask[complete]
 holoviews
+ipywidgets >= 7.2


### PR DESCRIPTION
I had `ipywidgets` v7.1 and ran into the import error in #185. Upgrading to 7.4 fixed it, and I confirmed that at least `import intake` works with  >= 7.2.