### PR TITLE
Fix for missing plugin situation

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -158,8 +158,9 @@ class LocalCatalogEntry(CatalogEntry):
         self._catalog_dir = catalog_dir
         self._catalog = catalog
         if isinstance(driver, str):
-            self._plugin = [get_plugin_class(driver)]
-            containers = set([self._plugin[0].container])
+            dr = get_plugin_class(driver)
+            self._plugin = [dr] if dr is not None else []
+            containers = set(p.container for p in self._plugin)
         elif isinstance(driver, list):
             self._plugin = [get_plugin_class(d) for d in driver]
             self._plugin = [p for p in self._plugin if p is not None]

--- a/intake/catalog/tests/multi_plugins.yaml
+++ b/intake/catalog/tests/multi_plugins.yaml
@@ -53,3 +53,18 @@ sources:
       myplug2:
           class: csv
     metadata: {}
+  tables6:
+    args:
+        urlpath: "{{ CATALOG_DIR }}/files*"
+    description: "no valid plugin in list"
+    driver:
+      myplug:
+          class: doesnotexist
+    metadata: {}
+  tables7:
+    args:
+        urlpath: "{{ CATALOG_DIR }}/files*"
+    description: "no valid plugin"
+    driver: doesnotexist
+    metadata: {}
+

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -413,3 +413,14 @@ def test_multi_plugins():
     fn = abspath('multi_plugins2.yaml')
     with pytest.raises(ValueError):
         open_catalog(fn)
+
+
+def test_no_plugins():
+    fn = abspath('multi_plugins.yaml')
+    cat = open_catalog(fn)
+    s = cat.tables6
+    with pytest.raises(ValueError):
+        s()
+    s = cat.tables7
+    with pytest.raises(ValueError):
+        s()


### PR DESCRIPTION
Fixes #187

The intended behaviour is that the entries should load OK, but that
the plugin attribute contains None, so that an attempt to *access*
the entry as a data source fails, but other entries are unaffected.

The message you get is like 
```
~/code/intake/intake/catalog/local.py in get(self, **user_parameters)
    235         if len(self._plugin) == 0:
    236             raise ValueError('No plugins loaded for this entry: %s'
--> 237                              % self._driver)
    238         elif isinstance(self._plugin, list):
    239             plugin = self._plugin[0]

ValueError: No plugins loaded for this entry: parquet
```
(although Intake has no way of knowing which conda package might contain the named driver)