### PR TITLE
Add special server-only attribute

### DIFF
--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -192,6 +192,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                 logger.debug("Opening entry %s" % entry)
                 source = entry.get(**user_parameters)
                 try:
+                    source.on_server = True
                     source.discover()
                 except Exception as e:
                     raise tornado.web.HTTPError(status_code=400,

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -95,6 +95,7 @@ class DataSource(object):
         self.npartitions = 0
         self._schema = None
         self.catalog_object = None
+        self.on_server = False
 
     def _get_cache(self, urlpath):
         if len(self.cache) == 0:


### PR DESCRIPTION
For sources like xarray, where serialising to a client may be somewhat
expensive (and error prone!), only do this when loaded by the server.

cc @jsignell 