### PR TITLE
Changes to allow to_spark

### DIFF
--- a/docs/source/plugin-directory.rst
+++ b/docs/source/plugin-directory.rst
@@ -8,7 +8,7 @@ This is a list of known projects which install driver plugins for Intake:
 * `intake-astro <https://github.com/ContinuumIO/intake-astro>`_ Table and array loading of FITS astronomical data
 * `intake-accumulo <https://github.com/ContinuumIO/intake-accumulo>`_ Apache Accumulo clustered data storage
 * `intake-avro <https://github.com/ContinuumIO/intake-avro>`_: Apache Avro data serialization format
-* `intake-dynamodb <https://github.com/informatics-lab/intake-dynamodb>`_
+* `intake-dynamodb <https://github.com/informatics-lab/intake-dynamodb>`_ link to Amazon DynamoDB
 * `intake-elasticsearch <https://github.com/ContinuumIO/intake-elasticsearch>`_: Elasticsearch search and analytics engine
 * `intake-geopandas <https://github.com/informatics-lab/intake_geopandas>`_: load ESRI Shape Files with geopandas
 * `intake-hbase <https://github.com/ContinuumIO/intake-hbase>`_: Apache HBase database
@@ -21,6 +21,7 @@ This is a list of known projects which install driver plugins for Intake:
 * `intake-postgres <https://github.com/ContinuumIO/intake-postgres>`_: PostgreSQL database
 * `intake-s3-manifests <https://github.com/informatics-lab/intake-s3-manifests>`_
 * `intake-solr <https://github.com/ContinuumIO/intake-solr>`_: Apache Solr search platform
+* `intake-spark <https://github.com/ContinuumIO/intake-spark>`_: data processed by Apache Spark
 * `intake-sql <https://github.com/ContinuumIO/intake-sql>`_: Generic SQL queries via SQLAlchemy
 * `intake-splunk <https://github.com/ContinuumIO/intake-splunk>`_: Splunk machine data query
 * `intake-xarray <https://github.com/ContinuumIO/intake-xarray>`_: load netCDF, Zarr and other multi-dimensional data

--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -31,10 +31,10 @@ Integration with Apache Spark
 The spark ecosystems and Intake will co-operate nicely! Firstly, Spark sources (i.e., named tables) will become
 standard data sources, so that the data can be streamed from Spark to a python process, and the data-sets referenced
 in a catalog as usual. These data-sets will necessarily be data-frame type, although an RDD-to-sequential method
-may also be possible
+may also be possible. See https://github.com/ContinuumIO/intake-spark
 
-Later, automatic streaming of data *into* Spark should be possible also, with a `to_spark()` method appearing on
-data-frame (and maybe sequence, later) type sources.
+Some sources will acquire a `to_spark()` method, translating the pythonic calls to something that can be
+passe to pyspark and giving back an RDD or DataFrame. See [PR](https://github.com/ContinuumIO/intake/pull/196).
 
 Derived Data-sets
 -----------------

--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -19,7 +19,7 @@ drivers that should be created by the Intake team, and those that might be contr
 community.
 
 Similarly, there are many third-party data services, some of which are paid and prorietary.
-Currently, `SQLCatalog`_ is the only example, and therefore reference, of this, but Intake will
+Currently, `SQLCatalog`_ is the first example, and therefore reference, of this, but Intake will
 become more universally useful when it can act as a bridge to several other systems.
 
 .. _SQLCatalog: https://intake-sql.readthedocs.io/en/latest/api.html#intake_sql.SQLCatalog

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -604,7 +604,6 @@ class YAMLFilesCatalog(Catalog):
         self._kwargs = kwargs.copy()
         self._cat_files = []
         self._cats = {}
-        self.name = "multi_yamls"
         super(YAMLFilesCatalog, self).__init__(**kwargs)
 
     def _load(self):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -132,7 +132,7 @@ class LocalCatalogEntry(CatalogEntry):
             Name of the plugin that can load this
         direct_access: bool
             Is the client allowed to attempt to reach this data
-        args: list
+        args: dict
             Passed when instantiating the plugin DataSource
         parameters: list
             UserParameters that can be set

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -215,7 +215,19 @@ class DataSource(object):
 
     def to_dask(self):
         """Return a dask container for this data source"""
-        pass
+        raise NotImplementedError
+
+    def to_spark(self):
+        """Provide an equivalent data object in Apache Spark
+
+        The mapping of python-oriented data containers to Spark ones will be
+        imperfect, and only a small number of drivers are expected to be able
+        to produce Spark objects. The standard arguments may b translated,
+        unsupported or ignored, depending on the specific driver.
+
+        This method requires the package intake-spark
+        """
+        raise NotImplementedError
 
     def close(self):
         """Close open resources corresponding to this data source."""

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -142,5 +142,15 @@ class CSVSource(base.DataSource, base.PatternMixin):
         self._get_schema()
         return self._dataframe
 
+    def to_spark(self):
+        from intake_spark.base import SparkHolder
+        h = SparkHolder(True, [
+            ('read', ),
+            ('format', ("csv", )),
+            ('option', ("header", "true")),
+            ('load', (self.urlpath, ))
+        ], {})
+        return h.setup()
+
     def _close(self):
         self._dataframe = None

--- a/intake/source/textfiles.py
+++ b/intake/source/textfiles.py
@@ -58,6 +58,13 @@ class TextFilesSource(base.DataSource):
         self._get_schema()
         return self.to_dask().compute()
 
+    def to_spark(self):
+        from intake_spark.base import SparkHolder
+        h = SparkHolder(False, [
+            ('textFile', (self._urlpath, ))
+        ], {})
+        return h.setup()
+
     def to_dask(self):
         import dask.bag as db
         from dask import delayed


### PR DESCRIPTION
Applies to CSV and textfiles.

Tests should be in intake-spark, no here.