### PR TITLE
Add pagination support to server and RemoteCatalog

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -251,7 +251,7 @@ class RemoteCatalog(Catalog):
             # and our own more direct context.
             try:
                 response.raise_for_status()
-            except HTTPError:
+            except requests.HTTPError:
                 raise RemoteCatalogError(
                     "Failed to fetch page of entries.")
             info = msgpack.unpackb(response.content, encoding='utf-8')
@@ -273,7 +273,7 @@ class RemoteCatalog(Catalog):
                 raise KeyError(name)
             try:
                 response.raise_for_status()
-            except HTTPError:
+            except requests.HTTPError:
                 raise RemoteCatalogError(
                     "Failed to fetch entry {!r}.".format(name))
             info = msgpack.unpackb(response.content, encoding='utf-8')
@@ -409,7 +409,7 @@ class RemoteCatalog(Catalog):
                                 **self._get_http_args())
         try:
             response.raise_for_status()
-        except HTTPError:
+        except requests.HTTPError:
             raise RemoteCatalogError(
                 "Failed to fetch metadata {!r}.".format(name))
         info = msgpack.unpackb(response.content, encoding='utf-8')

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -291,7 +291,7 @@ class RemoteCatalog(Catalog):
 
         page_size = self._page_size
 
-        class Entries:
+        class Entries(dict):
             """Mock enough of the dict interface.
 
             This fetches pages of entries from the server during iteration and

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -169,16 +169,17 @@ class Catalog(DataSource):
         
         Can also use attribute syntax, like ``cat.entry_name``.
         """
-        if key in self._entries:
+        try:
             return self._entries[key]
-        out = self
-        for k in key.split('.'):
-            if isinstance(out, CatalogEntry):
-                out = out()  # default parameters
-            if not isinstance(out, Catalog):
-                raise ValueError("Attempt to recurse into non-catalog")
-            out = getattr(out, k)
-        return out
+        except KeyError:
+            out = self
+            for k in key.split('.'):
+                if isinstance(out, CatalogEntry):
+                    out = out()  # default parameters
+                if not isinstance(out, Catalog):
+                    raise ValueError("Attempt to recurse into non-catalog")
+                out = getattr(out, k)
+            return out
 
     def discover(self):
         return {"container": 'catalog', 'shape': None,

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -349,7 +349,9 @@ class RemoteCatalog(Catalog):
             getenv=self.getenv,
             getshell=self.getshell,
             auth=self.auth,
-            http_args=self.http_args, **source)
+            http_args=self.http_args,
+            page_size=self._page_size,
+            **source)
             for source in info['sources']}
         return page
 
@@ -371,7 +373,9 @@ class RemoteCatalog(Catalog):
             getenv=self.getenv,
             getshell=self.getshell,
             auth=self.auth,
-            http_args=self.http_args, **info['source'])
+            http_args=self.http_args,
+            page_size=self._page_size,
+            **info['source'])
 
     def _get_http_args(self):
         """

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -409,7 +409,7 @@ class RemoteCatalog(Catalog):
             response.raise_for_status()
         except requests.HTTPError:
             raise RemoteCatalogError(
-                "Failed to fetch metadata {!r}.".format(name))
+                "Failed to fetch metadata.")
         info = msgpack.unpackb(response.content, encoding='utf-8')
         self.metadata = info['metadata']
         self._entries.reset()

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -333,8 +333,11 @@ class RemoteCatalog(Catalog):
                      page_offset, page_offset + self._page_size)
         params = {'page_offset': page_offset,
                   'page_size': self._page_size}
-        response = requests.get(self.info_url, params=params,
-                                **self._get_http_args())
+        http_args = self._get_http_args()
+        merged_params = http_args.get('params', {})
+        merged_params.update(params)
+        http_args['params'] = merged_params
+        response = requests.get(self.info_url, **http_args)
         # Produce a chained exception with both the underlying HTTPError
         # and our own more direct context.
         try:
@@ -358,8 +361,11 @@ class RemoteCatalog(Catalog):
     def fetch_by_name(self, name):
         logger.debug("Requesting info about entry named '%s'", name)
         params = {'name': name}
-        response = requests.get(self.source_url, params=params,
-                                **self._get_http_args())
+        http_args = self._get_http_args()
+        merged_params = http_args.get('params', {})
+        merged_params.update(params)
+        http_args['params'] = merged_params
+        response = requests.get(self.source_url, **http_args)
         if response.status_code == 404:
             raise KeyError(name)
         try:
@@ -407,8 +413,11 @@ class RemoteCatalog(Catalog):
         else:
             # Just fetch the metadata now; fetch source info later in pages.
             params = {'page_offset': 0, 'page_size': 0}
-        response = requests.get(self.info_url, params=params,
-                                **self._get_http_args())
+        http_args = self._get_http_args()
+        merged_params = http_args.get('params', {})
+        merged_params.update(params)
+        http_args['params'] = merged_params
+        response = requests.get(self.info_url, **http_args)
         try:
             response.raise_for_status()
         except requests.HTTPError:

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -91,7 +91,7 @@ def open_remote(url, entry, container, user_parameters, description, http_args,
         else:
             # Proxied access
             if container == 'catalog':
-                # Propage the page_size setting into nested Catalogs.
+                # Propagate the page_size setting into nested Catalogs.
                 response['page_size'] = page_size
             source = container_map[container](
                 url, http_args, parameters=user_parameters,

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -235,3 +235,25 @@ def test_remote_arr(intake_server):
     assert s.npartitions == 2
     assert s.read_partition(0).ravel().tolist() == list(range(50))
     assert s.read().ravel().tolist() == list(range(100))
+
+
+def test_pagination(intake_server):
+    PAGE_SIZE = 2
+    catalog = Catalog(intake_server, page_size=PAGE_SIZE)
+    assert len(catalog._entries._page_cache) == 0
+    assert len(catalog._entries._direct_lookup_cache) == 0
+    # Trigger fetching one specific name.
+    catalog['arr']
+    assert len(catalog._entries._page_cache) == 0
+    assert len(catalog._entries._direct_lookup_cache) == 1
+    # Trigger fetching just one full page.
+    list(zip(range(PAGE_SIZE), catalog))
+    assert len(catalog._entries._page_cache) == PAGE_SIZE
+    assert len(catalog._entries._direct_lookup_cache) == 1
+    # Trigger fetching all pages by list-ifying.
+    list(catalog)
+    assert len(catalog._entries._page_cache) > PAGE_SIZE
+    assert len(catalog._entries._direct_lookup_cache) == 1
+    # Now direct lookup by name should be free because everything is cached.
+    catalog['text']
+    assert len(catalog._entries._direct_lookup_cache) == 1

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -246,6 +246,10 @@ def test_pagination(intake_server):
     catalog['arr']
     assert len(catalog._entries._page_cache) == 0
     assert len(catalog._entries._direct_lookup_cache) == 1
+    # Using `in` on a Catalog should not iterate.
+    'arr' in catalog
+    assert len(catalog._entries._page_cache) == 0
+    assert len(catalog._entries._direct_lookup_cache) == 1
     # Trigger fetching just one full page.
     list(zip(range(PAGE_SIZE), catalog))
     assert len(catalog._entries._page_cache) == PAGE_SIZE

--- a/intake/catalog/utils.py
+++ b/intake/catalog/utils.py
@@ -155,3 +155,7 @@ def coerce(dtype, value):
         return value
     op = COERCION_RULES[dtype]
     return op() if value is None else op(value)
+
+
+class RemoteCatalogError(Exception):
+    pass

--- a/intake/cli/server/__main__.py
+++ b/intake/cli/server/__main__.py
@@ -27,6 +27,8 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description='Intake Catalog Server')
     parser.add_argument('-p', '--port', type=int, default=conf['port'],
                         help='port number for server to listen on')
+    parser.add_argument('--list-entries', action='store_true',
+                        help='list catalog entries at startup')
     parser.add_argument('--sys-exit-on-sigterm', action='store_true',
                         help='internal flag used during unit testing to ensure '
                              '.coverage file is written')
@@ -48,8 +50,9 @@ def main(argv=None):
     catargs = catargs[0] if len(catargs) == 1 else catargs
     logger.info("catalog_args: %s" % catargs)
     catalog = open_catalog(catargs, flatten=args.flatten)
-
-    logger.info('Entries:' + ','.join(list(catalog)))
+    if args.list_entries:
+        # This is not a good idea if the Catalog is huge.
+        logger.info('Entries:' + ','.join(list(catalog)))
 
     logger.info('Listening on port %d' % args.port)
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -174,6 +174,13 @@ class ServerSourceHandler(tornado.web.RequestHandler):
         self.auth = auth
 
     def get(self):
+        """
+        Access one source's info.
+
+        This is for direct access to an entry by name for random access, which
+        is useful to the client when the whole catalog has not first been
+        listed and pulled locally (e.g., in the case of pagination).
+        """
         head = self.request.headers
         name = self.get_argument('name')
         if self.auth.allow_connect(head):

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -182,7 +182,18 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             else:
                 cat = self._catalog
             try:
-                source = cat[name]
+                # This would ideally be cat[name] and not access the interal
+                # structure cat._entries. However in the case of a client
+                # accessing RemoteCatalog['metadata'], we need the server to
+                # return 404 (which will prompt the client to check
+                # RemoteCatalog.metadata and thereby find what it is looking
+                # for). The server should not attempt to return metadata as a
+                # source, which it would do if we access cat['metadata'].
+                # Therefore we need to make sure `name` is really an entry by
+                # checking directly. If the attribute/key distinction is made
+                # sligtly less permissive in the future, this can be
+                # revisited.
+                source = cat._entries[name]
             except KeyError:
                 msg = 'No such entry'
                 raise tornado.web.HTTPError(status_code=404, log_message=msg,

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -85,8 +85,9 @@ class ServerInfoHandler(tornado.web.RequestHandler):
 
     def get(self):
         head = self.request.headers
-        page_size = self.get_argument('page[size]', None)
-        page_number = self.get_argument('page[number]', 1)
+        page_size = self.get_argument('page_size', None)
+        page_offset = self.get_argument('page_offset', 0)
+        print('page_size', page_size, 'page_offset', page_offset)
         if self.auth.allow_connect(head):
             if 'source_id' in head:
                 cat = self.cache.get(head['source_id'])
@@ -100,8 +101,8 @@ class ServerInfoHandler(tornado.web.RequestHandler):
                 # need pagination.
                 start = stop = None
             else:
-                start = (int(page_number) - 1) * int(page_size)
-                stop = int(page_number) * int(page_size)
+                start = int(page_offset)
+                stop = int(page_offset) + int(page_size)
             page = itertools.islice(cat.walk(depth=1).items(), start, stop)
             for name, source in page:
                 if self.auth.allow_access(head, source, self.catalog):

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -87,7 +87,6 @@ class ServerInfoHandler(tornado.web.RequestHandler):
         head = self.request.headers
         page_size = self.get_argument('page_size', None)
         page_offset = self.get_argument('page_offset', 0)
-        print('page_size', page_size, 'page_offset', page_offset)
         if self.auth.allow_connect(head):
             if 'source_id' in head:
                 cat = self.cache.get(head['source_id'])


### PR DESCRIPTION
Thanks for this excellent project!

I have a Catalog with ~10k entries. (It happens to be backed by MongoDB, not YAML.) To make this scalable, I need to avoid pulling down all the entries from the server. This PR adds support for optional pagination parameters to the server's `GET /info` route and adds a new `GET /source` method to get the 'info' about one source. Respectively, these two server changes allow the `RemoteSource` to fetch entry info in batches during iteration (only pulling down as many as are used) and to fetch any specific entry's info by name (random access) when called on by `__getitem__`.

I have added some pagination unit tests. I have also interactively tested a client running on the `master` branch against a server running on this branch and vice versa. Each side gracefully falls back to non-paginated behavior when its peer does not support pagination.

In commit b1dabc4 I removed a redundant lookup but also made a slight API change: the Catalog metadata must now be accessed by attribute, not by `__getitem__`. Two small changes to existing tests were necessary to adjust for this. I believe this is an improvement. It is nice that entries are accessible by attribute, but I believe the inverse should _not_ be supported, lest the line between the library's core interface and its entries become too blurry and lead to confusing Tracebacks. If this change is controversial I am happy to rip it out into separate PR for further discussion.

Thanks in advance for taking a look.