### PR TITLE
Support search() on remote catalogs

### DIFF
--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -67,6 +67,29 @@ Returns
 Same as one of the entries in ``sources`` for ``GET /info``: the result of ``.describe()`` on the given data-source in the
 server
 
+POST /source, action="search"
+-----------------------------
+
+Searching a Catalog returns search results in the form of a new Catalog. This
+"results" Catalog is cached on the server the same as any other Catalog.
+
+Paramters
+~~~~~~~~~
+
+- ``source_id``, uuid string (optional): When the catalog being searched is not
+  the root catalog, but a subcatalog on the server, this is its unique
+  identifier. If the catalog being searched is the root Catalog, this parameter
+  should be omitted.
+- ``query``: tuple of ``(args, kwargs)``: These will be unpacked into
+  ``Catalog.search`` on the server to create the "results" Catalog.
+
+Returns
+~~~~~~~
+
+- ``source_id``, uuid string: the identifier of the results Catalog in the
+  server's source cache
+
+
 POST /source, action="open"
 ---------------------------
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -381,7 +381,8 @@ class RemoteCatalog(Catalog):
         logger.debug("Request page entries %d-%d",
                      page_offset, page_offset + self._page_size)
         params = {'page_offset': page_offset,
-                  'page_size': self._page_size}
+                  'page_size': self._page_size,
+                  'query': json.dumps(self._query)}
         http_args = self._get_http_args(params)
         response = requests.get(self.info_url, **http_args)
         # Produce a chained exception with both the underlying HTTPError
@@ -406,7 +407,7 @@ class RemoteCatalog(Catalog):
 
     def fetch_by_name(self, name):
         logger.debug("Requesting info about entry named '%s'", name)
-        params = {'name': name}
+        params = {'name': name, 'query': json.dumps(self._query)}
         http_args = self._get_http_args(params)
         response = requests.get(self.source_url, **http_args)
         if response.status_code == 404:
@@ -459,7 +460,7 @@ class RemoteCatalog(Catalog):
 
         if self.page_size is None:
             # Fetch all source info.
-            params = {}
+            params = {'query': json.dumps(self._query)}
         else:
             # Just fetch the metadata now; fetch source info later in pages.
             params = {'page_offset': 0, 'page_size': 0}

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -5,7 +5,6 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import base64
 import collections
 import copy
 import logging

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -353,6 +353,8 @@ class RemoteCatalog(Catalog):
         if not url.endswith('/'):
             url = url + '/'
         self.url = url
+        self.info_url = urljoin(url, 'v1/info')
+        self.source_url = urljoin(url, 'v1/source')
         self.http_args = http_args
         self.http_args.update(kwargs.get('storage_options', {}))
         self.http_args['headers'] = self.http_args.get('headers', {})
@@ -361,14 +363,10 @@ class RemoteCatalog(Catalog):
         self._query = tuple(query or ())
         self._source_id = kwargs.get('source_id', None)
         if self._source_id is None:
-            self.info_url = urljoin(url, 'v1/info')
-            self.source_url = urljoin(url, 'v1/source')
             self.name = urlparse(url).netloc.replace(
                 '.', '_').replace(':', '_')
         else:
             self.name = kwargs['name']
-            self.info_url = urljoin(url, 'v1/info')
-            self.source_url = urljoin(url, 'v1/source')
         self.auth = kwargs.get('auth', None)  # instance of BaseClientAuth
         super(RemoteCatalog, self).__init__(self, **kwargs)
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -357,7 +357,7 @@ class RemoteCatalog(Catalog):
         self.http_args['headers'] = self.http_args.get('headers', {})
         self._page_size = page_size
         # Convert to (immutable) tuple just to avoid accidental mutation.
-        self._query = tuple(query or (, ))
+        self._query = tuple(query or ())
         self._source_id = kwargs.get('source_id', None)
         if self._source_id is None:
             self.info_url = urljoin(url, 'v1/info')

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -322,9 +322,8 @@ class RemoteCatalog(Catalog):
             The number of entries fetched at a time during iteration.
             Default is None (no pagination; fetch all entries in bulk).
         query : Iterable or None
-            List from a sequence of progressive searches. Each element is
-            expected to be a valid argument to Catalog.search() for this
-            Catalog.
+            A sequence of progressive searches. Each element is expected to be
+            a valid argument to Catalog.search() for this Catalog.
         kwargs: may include catalog name, metadata, source ID (if known) and
             auth instance.
         name : str, optional
@@ -357,9 +356,8 @@ class RemoteCatalog(Catalog):
         self.http_args.update(kwargs.get('storage_options', {}))
         self.http_args['headers'] = self.http_args.get('headers', {})
         self._page_size = page_size
-        if query is None:
-            query = ()
-        self._query = tuple(query)
+        # Convert to (immutable) tuple just to avoid accidental mutation.
+        self._query = tuple(query or (, ))
         self._source_id = kwargs.get('source_id', None)
         if self._source_id is None:
             self.info_url = urljoin(url, 'v1/info')

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -504,7 +504,7 @@ class RemoteCatalog(Catalog):
             # filled in.
             name=("{!r}.search(".format(self) +
                   ", ".join("{!r}".format(arg) for arg in args) +
-                  ", " if kwargs else "" +
+                  (", " if kwargs else "") +
                   ", ".join("{!s}={!r}".format(k, v)
                             for k, v in kwargs.items()) +
                   ")"))

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -5,8 +5,8 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import base64
 import collections
-import json
 import logging
 import six
 import time
@@ -385,7 +385,11 @@ class RemoteCatalog(Catalog):
         params = {'page_offset': page_offset,
                   'page_size': self._page_size}
         if self._query:
-            params['query'] = json.dumps(self._query)
+            msgpack_encoded = msgpack.packb(self._query, use_bin_type=True)
+            # Base64-encode the msgpack bytes so that we can put them into a
+            # GET query parameter. Slice to omit the \n at the end.
+            base64_encoded = base64.encodebytes(msgpack_encoded)[:-1]
+            params['query'] = base64_encoded
         http_args = self._get_http_args(params)
         response = requests.get(self.info_url, **http_args)
         # Produce a chained exception with both the underlying HTTPError
@@ -412,7 +416,11 @@ class RemoteCatalog(Catalog):
         logger.debug("Requesting info about entry named '%s'", name)
         params = {'name': name}
         if self._query:
-            params['query'] = json.dumps(self._query)
+            msgpack_encoded = msgpack.packb(self._query, use_bin_type=True)
+            # Base64-encode the msgpack bytes so that we can put them into a
+            # GET query parameter. Slice to omit the \n at the end.
+            base64_encoded = base64.encodebytes(msgpack_encoded)[:-1]
+            params['query'] = base64_encoded
         http_args = self._get_http_args(params)
         response = requests.get(self.source_url, **http_args)
         if response.status_code == 404:
@@ -470,7 +478,11 @@ class RemoteCatalog(Catalog):
             # Just fetch the metadata now; fetch source info later in pages.
             params = {'page_offset': 0, 'page_size': 0}
         if self._query:
-            params['query'] = json.dumps(self._query)
+            msgpack_encoded = msgpack.packb(self._query, use_bin_type=True)
+            # Base64-encode the msgpack bytes so that we can put them into a
+            # GET query parameter. Slice to omit the \n at the end.
+            base64_encoded = base64.encodebytes(msgpack_encoded)[:-1]
+            params['query'] = base64_encoded
         http_args = self._get_http_args(params)
         response = requests.get(self.info_url, **http_args)
         try:

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -125,6 +125,7 @@ class Catalog(DataSource):
     def search(self, text, depth=2):
         words = text.lower().split()
         cat = Catalog(name=self.name + "_search",
+                      ttl=self.ttl,
                       getenv=self.getenv,
                       getshell=self.getshell,
                       auth=self.auth,

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -383,8 +383,9 @@ class RemoteCatalog(Catalog):
         logger.debug("Request page entries %d-%d",
                      page_offset, page_offset + self._page_size)
         params = {'page_offset': page_offset,
-                  'page_size': self._page_size,
-                  'query': json.dumps(self._query)}
+                  'page_size': self._page_size}
+        if self._query:
+            params['query'] = json.dumps(self._query)
         http_args = self._get_http_args(params)
         response = requests.get(self.info_url, **http_args)
         # Produce a chained exception with both the underlying HTTPError
@@ -409,7 +410,9 @@ class RemoteCatalog(Catalog):
 
     def fetch_by_name(self, name):
         logger.debug("Requesting info about entry named '%s'", name)
-        params = {'name': name, 'query': json.dumps(self._query)}
+        params = {'name': name}
+        if self._query:
+            params['query'] = json.dumps(self._query)
         http_args = self._get_http_args(params)
         response = requests.get(self.source_url, **http_args)
         if response.status_code == 404:
@@ -462,10 +465,12 @@ class RemoteCatalog(Catalog):
 
         if self.page_size is None:
             # Fetch all source info.
-            params = {'query': json.dumps(self._query)}
+            params = {}
         else:
             # Just fetch the metadata now; fetch source info later in pages.
             params = {'page_offset': 0, 'page_size': 0}
+        if self._query:
+            params['query'] = json.dumps(self._query)
         http_args = self._get_http_args(params)
         response = requests.get(self.info_url, **http_args)
         try:

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -7,6 +7,7 @@
 
 import base64
 import collections
+import copy
 import logging
 import six
 import time
@@ -308,7 +309,7 @@ class Entries(dict):
 
 class RemoteCatalog(Catalog):
     """The state of a remote Intake server"""
-    def __init__(self, url, http_args={}, page_size=None, **kwargs):
+    def __init__(self, url, http_args=None, page_size=None, **kwargs):
         """Connect to remote Intake Server as a catalog
 
         Parameters
@@ -343,6 +344,11 @@ class RemoteCatalog(Catalog):
             parameters to pass to remote backend file-system. Ignored for
             normal local files.
         """
+        if http_args is None:
+            http_args = {}
+        else:
+            # Make a deep copy to avoid mutating input.
+            http_args = copy.deepcopy(http_args)
         secure = http_args.pop('ssl', False)
         scheme = 'https' if secure else 'http'
         url = url.replace('intake', scheme)

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -505,11 +505,4 @@ class RemoteCatalog(Catalog):
             url=self.url,
             http_args=self.http_args,
             query=self._query + ((args, kwargs),),
-            # Give a name like <This Catalog>.search(...) with args and kwargs
-            # filled in.
-            name=("{!r}.search(".format(self) +
-                  ", ".join("{!r}".format(arg) for arg in args) +
-                  (", " if kwargs else "") +
-                  ", ".join("{!s}={!r}".format(k, v)
-                            for k, v in kwargs.items()) +
-                  ")"))
+            name="")

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -7,6 +7,7 @@
 
 import msgpack
 import requests
+from requests.compat import urljoin
 import six
 
 from ..source import registry as plugin_registry
@@ -90,8 +91,9 @@ def open_remote(url, entry, container, user_parameters, description, http_args,
                    name=entry,
                    parameters=user_parameters,
                    available_plugins=list(plugin_registry.keys()))
-    req = requests.post(url, data=msgpack.packb(
-        payload, use_bin_type=True), **http_args)
+    req = requests.post(urljoin(url, '/v1/source'),
+                        data=msgpack.packb(payload, use_bin_type=True),
+                        **http_args)
     if req.ok:
         response = msgpack.unpackb(req.content, **unpack_kwargs)
 

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from intake.source.tests.util import verify_datasource_interface
 from .util import assert_items_equal
-from intake import Catalog
+from intake import Catalog, RemoteCatalog
 from intake.catalog.remote import RemoteCatalogEntry
 
 TEST_CATALOG_PATH = os.path.join(os.path.dirname(__file__), 'catalog1.yml')
@@ -290,3 +290,18 @@ def test_getitem_and_getattr(intake_server):
     assert catalog.arr is catalog['arr']
     assert isinstance(catalog.arr, RemoteCatalogEntry)
     assert isinstance(catalog.metadata, (dict, type(None)))
+
+
+def test_search(intake_server):
+    catalog = Catalog(intake_server)
+
+    results = catalog.search('text', depth=1)
+    assert isinstance(results, RemoteCatalog)
+    assert list(results) == ['text']
+    assert isinstance(results['text'], RemoteCatalogEntry)
+
+    catalog = Catalog(intake_server)
+    results = catalog.search('text', depth=2)
+    assert isinstance(results, RemoteCatalog)
+    assert set(results) == set(['text', 'nested.text'])
+    assert isinstance(results['nested.text'], RemoteCatalogEntry)

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -337,3 +337,7 @@ def test_search(intake_server):
     assert isinstance(remote_results, RemoteCatalog)
     assert list(local_results) == list(remote_results) == expected
 
+
+def test_access_subcatalog(intake_server):
+    catalog = Catalog(intake_server)
+    catalog['nested']

--- a/intake/cli/sample/nested_catalog_example.yml
+++ b/intake/cli/sample/nested_catalog_example.yml
@@ -1,2 +1,0 @@
-sources:
-    - us_states

--- a/intake/cli/sample/nested_catalog_example.yml
+++ b/intake/cli/sample/nested_catalog_example.yml
@@ -1,0 +1,2 @@
+sources:
+    - us_states

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -288,7 +288,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                 source_id = self._cache.add(source)
                 logger.debug('Container: %s, ID: %s' % (source.container,
                                                         source_id))
-                response = dict(source._schema)
+                response = dict(source._schema or {})
                 response.update(dict(container=source.container,
                                      source_id=source_id,
                                      metadata=source.metadata))

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -234,7 +234,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             except KeyError:
                 try:
                     args, kwargs = query
-                    cat = cat.search(*args, **kwargs)
+                    results_cat = cat.search(*args, **kwargs)
                 except Exception as err:
                     logger.exception("Search query %r on Catalog %r failed",
                                      query, cat)
@@ -242,7 +242,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                         status_code=400,
                         log_message="Search query failed",
                         reason=str(err))
-                self._cache.add(cat, source_id=query_source_id)
+                self._cache.add(results_cat, source_id=query_source_id)
             response = {'source_id': query_source_id}
             self.write(msgpack.packb(response, use_bin_type=True))
             self.finish()

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -250,18 +250,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                         cat = cat.search(*args, **kwargs)
                         self._cache.add(cat, source_id=query_key)
             try:
-                # This would ideally be cat[name] and not access the interal
-                # structure cat._entries. However in the case of a client
-                # accessing RemoteCatalog['metadata'], we need the server to
-                # return 404 (which will prompt the client to check
-                # RemoteCatalog.metadata and thereby find what it is looking
-                # for). The server should not attempt to return metadata as a
-                # source, which it would do if we access cat['metadata'].
-                # Therefore we need to make sure `name` is really an entry by
-                # checking directly. If the attribute/key distinction is made
-                # sligtly less permissive in the future, this can be
-                # revisited.
-                source = cat._entries[name]
+                source = cat[name]
             except KeyError:
                 msg = 'No such entry'
                 raise tornado.web.HTTPError(status_code=404, log_message=msg,

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -114,11 +114,10 @@ class ServerInfoHandler(tornado.web.RequestHandler):
                 # This could be a search of a search of a serach (etc.).
                 # Progressively apply each search and then page through the
                 # final results.
-                refined_cat = cat
                 for query in query_list:
-                    refined_cat = refined_cat.search(query)
+                    cat = cat.search(query)
                 page = itertools.islice(
-                    refined_cat.walk(depth=1).items(), start, stop)
+                    cat.walk(depth=1).items(), start, stop)
             else:
                 # Page through all results.
                 page = itertools.islice(cat.walk(depth=1).items(), start, stop)
@@ -129,7 +128,7 @@ class ServerInfoHandler(tornado.web.RequestHandler):
                     sources.append(info)
 
             server_info = dict(version=__version__, sources=sources,
-                               metadata=self.catalog.metadata)
+                               metadata=cat.metadata)
         else:
             msg = 'Access forbidden'
             raise tornado.web.HTTPError(status_code=403, log_message=msg,

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -114,8 +114,8 @@ class ServerInfoHandler(tornado.web.RequestHandler):
                 # This could be a search of a search of a serach (etc.).
                 # Progressively apply each search and then page through the
                 # final results.
-                for query in query_list:
-                    cat = cat.search(query)
+                for args, kwargs in query_list:
+                    cat = cat.search(*args, **kwargs)
                 page = itertools.islice(
                     cat.walk(depth=1).items(), start, stop)
             else:
@@ -212,8 +212,8 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                 # Progressively apply each search and then page through the
                 # final results.
                 cat = cat
-                for query in query_list:
-                    cat = cat.search(query)
+                for args, kwargs, in query_list:
+                    cat = cat.search(*args, **kwargs)
             try:
                 # This would ideally be cat[name] and not access the interal
                 # structure cat._entries. However in the case of a client

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -6,7 +6,6 @@
 #-----------------------------------------------------------------------------
 from __future__ import print_function
 
-import base64
 import time
 from uuid import uuid4
 
@@ -109,8 +108,6 @@ class ServerInfoHandler(tornado.web.RequestHandler):
             else:
                 start = int(page_offset)
                 stop = int(page_offset) + int(page_size)
-                page = itertools.islice(
-                    cat.walk(depth=1).items(), start, stop)
             page = itertools.islice(cat.walk(depth=1).items(), start, stop)
             for name, source in page:
                 if self.auth.allow_access(head, source, self.catalog):
@@ -231,7 +228,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             # Construct a cache key from the source_id of the Catalog being
             # searched and the query itself.
             query_source_id = '-'.join((head.get('source_id', 'root'),
-                                       str(query)))
+                                        str(query)))
             try:
                 cat = self._cache.get(query_source_id)
             except KeyError:

--- a/intake/container/base.py
+++ b/intake/container/base.py
@@ -7,6 +7,7 @@
 
 import msgpack
 import requests
+from requests.compat import urljoin
 from intake.source.base import DataSource, Schema
 from . import serializer
 from ..compat import unpack_kwargs
@@ -47,8 +48,9 @@ class RemoteSource(DataSource):
         if self._source_id is None:
             payload = dict(action='open', name=self.name,
                            parameters=self.parameters)
-            req = requests.post(self.url, data=msgpack.packb(
-                payload, use_bin_type=True), **self.headers)
+            req = requests.post(urljoin(self.url, '/v1/source'),
+                                data=msgpack.packb(payload, use_bin_type=True),
+                                **self.headers)
             req.raise_for_status()
             response = msgpack.unpackb(req.content, **unpack_kwargs)
             self._parse_open_response(response)
@@ -103,8 +105,9 @@ def get_partition(url, headers, source_id, container, partition):
         payload['partition'] = partition
 
     try:
-        resp = requests.post(url, data=msgpack.packb(
-            payload, use_bin_type=True), **headers)
+        resp = requests.post(urljoin(url, '/v1/source'),
+                             data=msgpack.packb(payload, use_bin_type=True),
+                             **headers)
         if resp.status_code != 200:
             raise Exception('Error reading data')
 


### PR DESCRIPTION
Submitted for a first-pass review. Needs tests. There is some work in progress on making a nested catalog...I'm not exactly sure how to formulate that in YAML and wouldn't mind a nudge in the right direction.

This supports:

1. "Progressive" search: search on a Catalog that is itself a set of search results.
2. Searching on a Catalog that is nested inside another Catalog

See an example illustrating both [at this section of a notebook](https://nbviewer.jupyter.org/github/danielballan/intake-bluesky/blob/master/demo.ipynb#Progressive-Search). The Catalog in that example is backed by MongoDB, and so its `search()` method expects a dict (to be precise, a dict that is a valid Mongo Query) but in general this PR accommodates any single argument to `search()`, including the `text` search that is implemented in intake's own Catalogs.

This PR implements progressive search by caching the chain of queries accumulated over chained searched and iteratively applying them each time. This could be made more efficient: one could imagine adding an optional `optimized_multi_search()` method that expects a _list_ of queries and does internal optimization. I'd be happy to include that in this PR, but I'll hold off until we agree that the basic outline is good.
        