### PR TITLE
Reduce build data duplication

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,3 +1,5 @@
+{% set data = load_setup_py_data() %}
+
 package:
    name: intake
    version: {{ environ.get('GIT_DESCRIBE_TAG', 'unknown') }}
@@ -42,7 +44,7 @@ test:
     - py.test --pyargs -v intake
 
 about:
-  home: https://github.com/ContinuumIO/intake
-  license: BSD
+  home: {{ data['url'] }}
+  license: {{ data['license'] }}
   license_file: LICENSE
-  summary: Data ingest catalog system
+  summary: {{ data['description'] }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,16 +23,16 @@ requirements:
   run:
     - python
     - numpy
-    - pandas
-    - msgpack-python
-    - msgpack-numpy
-    - requests
-    - tornado
-    - jinja2
+
+    {% for dep in data['install_requires'] %}
+    {% if "ruamel.yaml" not in dep %}
+    - {{ dep.lower() }}
+    {% endif %}
+    {% endfor %}
+
+    # There is an unfortunate name difference for this package in the main
+    # conda repo. This can be removed when/if ruamel.yaml becomes available
     - ruamel_yaml >=0.15.0
-    - dask >=0.17.0
-    - python-snappy
-    - appdirs
 
 test:
   requires:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,8 +10,9 @@ source:
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   entry_points:
-    - intake-server = intake.cli.server.__main__:main
-    - intake = intake.cli.client.__main__:main
+    {% for entry in data['entry_points']['console_scripts'] %}
+    - {{ entry }}
+    {% endfor %}
   script: python setup.py install --single-version-externally-managed --record=record.txt
   noarch: python
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
    name: intake
-   version: {{ environ.get('GIT_DESCRIBE_TAG', 'unknown') }}
+   version:  {{ data['version'] }}
 
 source:
    path: ..

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+# This file is also processed by conda-build, so keep spaces as "pkg >=1.2"
 appdirs
-dask[complete]
+dask >=0.17.0
 holoviews
-ipywidgets >= 7.2
+ipywidgets >=7.2
 jinja2
 msgpack-numpy
 msgpack-python
@@ -9,6 +10,6 @@ numpy
 pandas
 python-snappy
 requests
-ruamel.yaml >= 0.15.0
+ruamel.yaml >=0.15.0
 six
-tornado >= 4.5.1
+tornado >=4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ msgpack-numpy
 msgpack-python
 numpy
 pandas
-pytest
 python-snappy
 requests
 ruamel.yaml >= 0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+appdirs
+dask[complete]
+holoviews
+ipywidgets >= 7.2
 jinja2
 msgpack-numpy
 msgpack-python
@@ -5,11 +9,7 @@ numpy
 pandas
 pytest
 python-snappy
-ruamel.yaml >= 0.15.0
 requests
-appdirs
+ruamel.yaml >= 0.15.0
 six
 tornado >= 4.5.1
-dask[complete]
-holoviews
-ipywidgets >= 7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 appdirs
 dask >=0.17.0
 holoviews
-ipywidgets >=7.2
 jinja2
 msgpack-numpy
 msgpack-python

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@
 from setuptools import setup, find_packages
 import versioneer
 
-
-requires = open('requirements.txt').read().strip().split('\n')
+requires = [line.strip() for line in open('requirements.txt').readlines() if not line.startswith("#")]
 
 setup(
     name='intake',


### PR DESCRIPTION
@martindurant This PR does this following (it may be simpler to look at each commit individually, they are all standalone):

* Alphabetizes the contents of `requirements.txt`

  Slightly helpful to have

* Removes `pytest` from `requirements.txt`

  Not sure why this should be here, but let me know if this commit should be reverted

* pulls "about" data fields from `setup.py`

  This is accomplished by using `{% set data = load_setup_py_data() %}` with the templating facility conda-build provides for `meta.yaml` files

* pulls entry point definitions from `setup.py`

  Same mechanism as "about" fields

* use `requirements.txt` for runtime deps everywhere

  This will need your judgment. After some experiences with botched/out of sync releases for Bokeh, I fall heavily on the side of "not repeating configuration". However, the situation for intake is slightly complicated relative to Bokeh, due to:

  * the `ruamal.yaml` vs `ruamel_yaml` mess. It's special cased in the `meta.yaml` in a somewhat ugly way. However, if you will be moving to using conda-forge, or if the main repo ever changes to agree with pypi and conda-forge naming, then this special case could be removed.

  * `dask[complete]` changed to `dask >=0.17.0` Would need to verify that other dependencies cover the things you actually need, or add them if not. I assume npy and csv readers are covered by `numpy` and `pandas` packages but this should be confirmed. 