### PR TITLE
Codebase Linting

### DIFF
--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -16,9 +16,6 @@ class CatalogEntry(object):
         self.getenv = getenv
         self.getshell = getshell
 
-    def __repr__(self):
-        return repr(self.describe())
-
     def describe(self):
         """Get a dictionary of attributes of this entry.
 

--- a/intake/catalog/tests/test_auth_integration.py
+++ b/intake/catalog/tests/test_auth_integration.py
@@ -13,7 +13,6 @@ import time
 
 import pytest
 
-from .util import assert_items_equal
 from intake import Catalog
 
 from intake.auth.secret import SecretClientAuth

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -293,16 +293,16 @@ def test_duplicate_data_sources():
     path = os.path.dirname(__file__)
     uri = os.path.join(path, 'catalog_dup_sources.yml')
 
-    with pytest.raises(exceptions.DuplicateKeyError) as except_info:
-        c = Catalog(uri)
+    with pytest.raises(exceptions.DuplicateKeyError):
+        Catalog(uri)
 
 
 def test_duplicate_parameters():
     path = os.path.dirname(__file__)
     uri = os.path.join(path, 'catalog_dup_parameters.yml')
 
-    with pytest.raises(exceptions.DuplicateKeyError) as except_info:
-        c = Catalog(uri)
+    with pytest.raises(exceptions.DuplicateKeyError):
+        Catalog(uri)
 
 
 @pytest.fixture

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -73,7 +73,7 @@ def test_environment_evaluation(intake_server):
     catalog = Catalog(intake_server)
     import os
     os.environ['INTAKE_TEST'] = 'client'
-    d = catalog['remote_env']
+    catalog['remote_env']
 
 
 def test_read(intake_server):

--- a/intake/cli/client/tests/test_cache.py
+++ b/intake/cli/client/tests/test_cache.py
@@ -12,7 +12,7 @@ import os
 import pytest
 import subprocess
 import sys
-from intake.source.tests.util import temp_cache
+from intake.source.tests.util import temp_cache # NOQA
 cpath = os.path.abspath(
     os.path.join(os.path.dirname(__file__),
                  '../../../catalog/tests/catalog_caching.yml'))

--- a/intake/cli/client/tests/test_cache.py
+++ b/intake/cli/client/tests/test_cache.py
@@ -12,7 +12,6 @@ import os
 import pytest
 import subprocess
 import sys
-from intake.source.tests.util import temp_cache # NOQA
 cpath = os.path.abspath(
     os.path.join(os.path.dirname(__file__),
                  '../../../catalog/tests/catalog_caching.yml'))

--- a/intake/cli/client/tests/test_conf.py
+++ b/intake/cli/client/tests/test_conf.py
@@ -7,7 +7,6 @@
 
 import os
 import subprocess
-import pytest
 
 
 def test_reset(tempdir):

--- a/intake/cli/client/tests/test_local_integration.py
+++ b/intake/cli/client/tests/test_local_integration.py
@@ -9,7 +9,6 @@ import os.path
 import subprocess
 import tempfile
 import shutil
-import sys
 
 import pytest
 

--- a/intake/cli/server/__main__.py
+++ b/intake/cli/server/__main__.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 
 import argparse
 import logging
-import os
 import signal
 import sys
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -12,7 +12,6 @@ from uuid import uuid4
 import itertools
 import logging
 import msgpack
-import pickle
 import tornado.gen
 import tornado.ioloop
 import tornado.web

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -103,7 +103,6 @@ class TestServerV1Source(TestServerV1Base):
         return responses
 
     def test_open(self):
-        import pickle
         msg = dict(action='open', name='entry1', parameters={})
         resp_msg, = self.make_post_request(msg)
 

--- a/intake/conftest.py
+++ b/intake/conftest.py
@@ -132,3 +132,20 @@ def tempdir():
         yield d
     finally:
         shutil.rmtree(d)
+
+
+@pytest.fixture
+def temp_cache(tempdir):
+    import intake
+    old = intake.config.conf.copy()
+    olddir = intake.config.confdir
+    intake.config.confdir = str(tempdir)
+    intake.config.conf.update({'cache_dir': str(tempdir),
+                               'cache_download_progress': False,
+                               'cache_disabled': False})
+    intake.config.save_conf()
+    try:
+        yield
+    finally:
+        intake.config.confdir = olddir
+        intake.config.conf.update(old)

--- a/intake/container/serializer.py
+++ b/intake/container/serializer.py
@@ -58,7 +58,6 @@ class MsgPackSerializer(object):
             import msgpack_numpy
             return msgpack.packb(obj, default=msgpack_numpy.encode)
         elif container == 'dataframe':
-            import pandas as pd
             return obj.to_msgpack()
         else:
             return msgpack.packb(obj, use_bin_type=True)

--- a/intake/source/tests/test_cache.py
+++ b/intake/source/tests/test_cache.py
@@ -12,7 +12,6 @@ import shutil
 from intake.source.cache import FileCache, CacheMetadata
 import intake
 import intake.config
-from intake.source.tests.util import temp_cache # NOQA
 here = os.path.dirname(os.path.abspath(__file__))
 import logging
 logger = logging.getLogger('intake')

--- a/intake/source/tests/test_cache.py
+++ b/intake/source/tests/test_cache.py
@@ -12,7 +12,7 @@ import shutil
 from intake.source.cache import FileCache, CacheMetadata
 import intake
 import intake.config
-from intake.source.tests.util import temp_cache
+from intake.source.tests.util import temp_cache # NOQA
 here = os.path.dirname(os.path.abspath(__file__))
 import logging
 logger = logging.getLogger('intake')

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -196,7 +196,7 @@ def test_plot(sample1_datasource):
     import holoviews
 
     p = sample1_datasource.plot()
-    assert isinstance(sample1_datasource.plot(), holoviews.NdOverlay)
+    assert isinstance(p, holoviews.NdOverlay)
 
 
 def test_close(sample1_datasource, data_filenames):

--- a/intake/source/tests/test_discovery.py
+++ b/intake/source/tests/test_discovery.py
@@ -46,4 +46,4 @@ def test_discover_pluginprefix(extra_pythonpath):
 
 def test_discover_collision(extra_pythonpath):
     with pytest.warns(UserWarning):
-        registry = discovery.autodiscover(plugin_prefix='collision_')
+        discovery.autodiscover(plugin_prefix='collision_')

--- a/intake/source/tests/util.py
+++ b/intake/source/tests/util.py
@@ -5,8 +5,6 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import pytest
-
 
 def verify_plugin_interface(plugin):
     assert isinstance(plugin.version, str)
@@ -22,20 +20,3 @@ def verify_datasource_interface(source):
     for method in ['discover', 'read', 'read_chunked', 'read_partition',
                    'to_dask', 'close']:
         assert hasattr(source, method)
-
-
-@pytest.fixture
-def temp_cache(tempdir):
-    import intake
-    old = intake.config.conf.copy()
-    olddir = intake.config.confdir
-    intake.config.confdir = str(tempdir)
-    intake.config.conf.update({'cache_dir': str(tempdir),
-                               'cache_download_progress': False,
-                               'cache_disabled': False})
-    intake.config.save_conf()
-    try:
-        yield
-    finally:
-        intake.config.confdir = olddir
-        intake.config.conf.update(old)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,20 @@
+[flake8]
+# References:
+# http://flake8.readthedocs.org/en/latest/config.html
+# http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+#
+# Style checks turned on:
+#   F - all pyflake errors
+#   E101 - indentation contains mixed spaces and tabs
+#   E111 - indentation is not a multiple of four
+#   E501 - line too long (see max-line-length)
+
+# Note: there cannot be spaces after comma's here
+exclude = __init__.py
+ignore = E,W
+select = F,E101,E111,E501
+max-line-length = 165
+
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
@martindurant another small PR for you. This one

* Adds a baseline configuration for flake8. I just used what is in Bokeh:

  ```
  #   F - all pyflake errors
  #   E101 - indentation contains mixed spaces and tabs
  #   E111 - indentation is not a multiple of four
  #   E501 - line too long (see max-line-length)
  ```
   The current max line length is 165. 

* cleans up all warnings based on the configuration above
 
  The only thing of note is that I moved a pytest fixture to `conftest.py` to avoid having to import, which I think is a good idea anyway. 

### Questions

Things to consider:

* Are these the right Flake8 rules for Intake? 
* Do you want to check and enforce flake8 automatically in a CI job?
* Do you want to document a Git `pre-commit` hook to run this before allowing a commit?
