### PR TITLE
Run tests with pytest

### DIFF
--- a/.ci-coveragerc
+++ b/.ci-coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = intake/*, *tests/*, */_version.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,9 @@
 [run]
 omit =
+    */tests/*
     */test_*.py
     *_version.py
-source = 
+source =
     intake
 [report]
 show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
     # ANACONDA_TOKEN
     secure: XJ+hvBFtSNUy6xYQmpEFVoR1MTYdTtLIN9R46qfW5XhAOEzuA0mDBd4FL9mgaw4+hoB4+3B8ItHquGxRN/ugw8O/VRA5CuGBbmfbJfG2vLKAbe3RruTueijbxIpiPAhgEp11HtLWGYiaXR47Hug/hO5nFnHAqF9DpQfvsO5ntlFcMnNRVFp7uHbkdz651yQ3en4frSLP/07sK7zGMculb5VKeFH7RdD7Imyqi/BqXX3Mq4ymcgJ/lSEbgO46hP1wX6q4/SSFEQyb4tUUgM6yK6nZEjs6R6DLXpW9PFncTHsjBu39+aZR5tFQqRFOMoaVY2WVxDFSC4Hx8kUXuDQMfuR4JgVOEDSDLr8iws7Fr7svWEpz0TfasbN2/j4LSL+4bjtpZE/Baz3TrUf1LsmbjIgGIDiruLcVpQLrD3msHjjHiyldUs3gDCjndPuaxg0f3AKz/04xNXTNxg+RyVIGjP/6dHDRNIyHfToBhkt42wjt4bDiyxK78ty5Qn+EnDPJn1R22dULFXTwMnEO9QbzJCKZz2xwClp8toxHYRTUsjD68IDxipqd4gn6R16OgMcA9wtzomoz5UmFbo3ambUluzMVv3v9KS4spqykPWF8wTuGfJy2pEJAm6E9bwa4Jw1RZx9GWSYp/Zm8QR0Vx10dTTy/X7/wX44f/P9pv/dQUiw=
 
+before_install:
+  - export PATH="$HOME/miniconda3/bin:$PATH"
+
 install: scripts/ci/install.sh
 
 script: scripts/ci/build.sh

--- a/intake/.coveragerc
+++ b/intake/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *tests/*, */_version.py

--- a/intake/.coveragerc
+++ b/intake/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = *tests/*, */_version.py

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -11,7 +11,7 @@ import pickle
 import pytest
 import pandas as pd
 
-from ...source.tests.util import verify_datasource_interface
+from intake.source.tests.util import verify_datasource_interface
 from .util import assert_items_equal
 from intake import Catalog
 from intake.catalog.remote import RemoteCatalogEntry

--- a/intake/catalog/tests/test_utils.py
+++ b/intake/catalog/tests/test_utils.py
@@ -5,7 +5,7 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from .. import utils
+import intake.catalog.utils as utils
 
 
 def test_expand_templates():

--- a/intake/catalog/tests/util.py
+++ b/intake/catalog/tests/util.py
@@ -5,7 +5,7 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from ...source import base, registry
+from intake.source import base, registry
 
 
 def assert_items_equal(a, b):

--- a/intake/source/tests/test_base.py
+++ b/intake/source/tests/test_base.py
@@ -12,7 +12,7 @@ import pytest
 import numpy as np
 import pandas as pd
 
-from .. import base
+import intake.source.base as base
 
 
 def test_datasource_base_method_exceptions():

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -11,7 +11,7 @@ import pickle
 import pytest
 import pandas as pd
 
-from .. import csv
+import intake.source.csv as csv
 from .util import verify_plugin_interface, verify_datasource_interface
 
 

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -2,8 +2,6 @@
 
 set -e # exit on error
 
-source ${HOME}/miniconda3/bin/activate root
-
 echo "Building conda package."
 conda build -c defaults -c conda-forge --no-test ./conda
 

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -14,5 +14,5 @@ else
     conda install -y --use-local intake
 
     echo "Running unit tests."
-    py.test --cov intake  --cov-config=intake/.coveragerc
+    py.test
 fi

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -4,16 +4,17 @@ set -e # exit on error
 
 source ${HOME}/miniconda3/bin/activate root
 
-# Workaround for Travis-CI bug #2: https://github.com/travis-ci/travis-ci/issues/7773
-if ! [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    EXTRA_OPTS="--no-test"
-fi
-
 echo "Building conda package."
-conda build -c defaults -c conda-forge ${EXTRA_OPTS:-} ./conda
+conda build -c defaults -c conda-forge --no-test ./conda
 
-# If tagged, upload package to main channel
+# If tagged, upload package to main channel, otherwise, run tests
 if [ -n "$TRAVIS_TAG" ]; then
     echo "Uploading conda package."
     anaconda -t ${ANACONDA_TOKEN} upload -u intake --force `conda build --output ./conda`
+else
+    echo "Installing conda package locally."
+    conda install -y --use-local intake
+
+    echo "Running unit tests."
+    py.test --cov intake  --cov-config=intake/.coveragerc
 fi

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -4,9 +4,6 @@ set -e # exit on error
 
 CONDA_REQS="conda-build=3.17.0 anaconda-client=1.7.2 conda-verify=3.1.1"
 
-# TODO: ideally this could be read from the conda recipe
-TEST_REQS="pytest pytest-cov coverage"
-
 PLATFORM="$(case $TRAVIS_OS_NAME in (linux) echo Linux;; (osx) echo MacOSX;;esac)"
 
 echo "Installing Miniconda."
@@ -24,4 +21,7 @@ echo -e "$PINNED_PKGS" > $HOME/miniconda3/conda-meta/pinned
 
 echo "Configuring conda."
 conda config --set auto_update_conda off
-conda install --yes ${CONDA_REQS} ${TEST_REQS}
+conda install --yes ${CONDA_REQS}
+
+echo "Installing test dependencies."
+conda install --yes `python scripts/deps.py`

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -23,6 +23,5 @@ mkdir -p $HOME/miniconda3/conda-meta
 echo -e "$PINNED_PKGS" > $HOME/miniconda3/conda-meta/pinned
 
 echo "Configuring conda."
-source ${HOME}/miniconda3/bin/activate root
 conda config --set auto_update_conda off
 conda install --yes ${CONDA_REQS} ${TEST_REQS}

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -4,6 +4,9 @@ set -e # exit on error
 
 CONDA_REQS="conda-build=3.17.0 anaconda-client=1.7.2 conda-verify=3.1.1"
 
+# TODO: ideally this could be read from the conda recipe
+TEST_REQS="pytest pytest-cov coverage"
+
 PLATFORM="$(case $TRAVIS_OS_NAME in (linux) echo Linux;; (osx) echo MacOSX;;esac)"
 
 echo "Installing Miniconda."
@@ -22,4 +25,4 @@ echo -e "$PINNED_PKGS" > $HOME/miniconda3/conda-meta/pinned
 echo "Configuring conda."
 source ${HOME}/miniconda3/bin/activate root
 conda config --set auto_update_conda off
-conda install --yes ${CONDA_REQS}
+conda install --yes ${CONDA_REQS} ${TEST_REQS}

--- a/scripts/deps.py
+++ b/scripts/deps.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+from conda_build.api import render
+
+# This is needed because render spams the console
+old_stdout = sys.stdout
+sys.stdout = open(os.devnull, 'w')
+sys.stderr = open(os.devnull, 'w')
+
+meta = render('conda')[0][0].meta
+
+sys.stdout = old_stdout
+print(' '.join(meta['test']['requires']))


### PR DESCRIPTION
This PR addresses #129:

* `conda-build` is unconditionally invoked with `--no-test`
* for non-release (i.e. non-tagged) build, the local package is installed and tests are run with `pytest`
* adds `miniconda3/bin` to `PATH` in the `before_install` of `.travis.yml` to reduce duplication
* reports test coverage results

I have also aped a pattern from Bokeh with `deps.py` to report out the test dependencies so that they can be installed easily by conda without duplicating the information from the recipe. 