### PR TITLE
Misc CLI work

### DIFF
--- a/intake/cli/client/__main__.py
+++ b/intake/cli/client/__main__.py
@@ -165,7 +165,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv
 
-    parser = argparse.ArgumentParser(description='Intake Catalog CLI', add_help=False)
+    parser = argparse.ArgumentParser(description='Intake Catalog CLI')
     subparsers = parser.add_subparsers(help='sub-command help')
 
     parser.add_argument('-v', '--version', action='version', version=__version__)

--- a/intake/cli/client/__main__.py
+++ b/intake/cli/client/__main__.py
@@ -12,6 +12,14 @@ import argparse
 import shutil
 import yaml
 
+def _version(modname, attr):
+    from importlib import import_module
+    try:
+        mod = import_module(modname)
+        return getattr(mod, attr)
+    except ImportError:
+        pass
+
 from intake import Catalog, __version__
 
 def print_entry_info(catalog, name):
@@ -19,6 +27,15 @@ def print_entry_info(catalog, name):
     for key in sorted(info.keys()):
         print("[{}] {}={}".format(name, key, info[key]))
 
+def info(args):
+    if_installed = lambda version_or_none: version_or_none or "(not installed)"
+    print("Python version      :  %s" % sys.version.split('\n')[0])
+    print("IPython version     :  %s" % if_installed(_version('IPython', '__version__')))
+    print("Tornado version     :  %s" % if_installed(_version('tornado', 'version')))
+    print("Dask version        :  %s" % if_installed(_version('dask', '__version__')))
+    print("Pandas version      :  %s" % if_installed(_version('pandas', '__version__')))
+    print("Numpy version       :  %s" % if_installed(_version('numpy', '__version__')))
+    print("Intake version      :  %s" % __version__)
 
 def listing(args):
     catalog = Catalog(args.uri)
@@ -169,6 +186,9 @@ def main(argv=None):
     subparsers = parser.add_subparsers(help='sub-command help')
 
     parser.add_argument('-v', '--version', action='version', version=__version__)
+
+    info_parser = subparsers.add_parser('info', help='Intake package runtime info')
+    info_parser.set_defaults(func=info)
 
     list_parser = subparsers.add_parser('list', help='catalog listing')
     list_parser.add_argument('--full', action='store_true')

--- a/intake/cli/client/__main__.py
+++ b/intake/cli/client/__main__.py
@@ -12,8 +12,7 @@ import argparse
 import shutil
 import yaml
 
-from intake import Catalog
-
+from intake import Catalog, __version__
 
 def print_entry_info(catalog, name):
     info = catalog[name].describe()
@@ -168,6 +167,8 @@ def main(argv=None):
 
     parser = argparse.ArgumentParser(description='Intake Catalog CLI', add_help=False)
     subparsers = parser.add_subparsers(help='sub-command help')
+
+    parser.add_argument('-v', '--version', action='version', version=__version__)
 
     list_parser = subparsers.add_parser('list', help='catalog listing')
     list_parser.add_argument('--full', action='store_true')


### PR DESCRIPTION
@martindurant In thinking about an eventual `intake browser` command, I had a peek at the CLI code. It was missing some small things I think are useful/common so I made a quick PR to add them:

* enable `-h` for default help:

  <img width="597" alt="screen shot 2019-01-10 at 10 40 10" src="https://user-images.githubusercontent.com/1078448/50989413-2cd7da80-14c4-11e9-8ba2-d342c2892fa2.png">

* add `-v` for reporting version:

  <img width="513" alt="screen shot 2019-01-10 at 10 40 56" src="https://user-images.githubusercontent.com/1078448/50989436-4416c800-14c4-11e9-973c-f75c0717ab11.png">

* add `intake info` command to report runtime env information, similar to `bokeh info`. This is very useful as a dead-simple ask to users to run to report intake-specific dependencies and configuration. 

  <img width="526" alt="screen shot 2019-01-10 at 10 42 37" src="https://user-images.githubusercontent.com/1078448/50989545-84764600-14c4-11e9-81c7-32bd52f46f17.png">

  I realize there its the `intake config list-defaults` already but that seems to serve a different purpose. Or perhaps they could be merged. 

---

I wanted to ask about more work before proceeding. I do think from a software design/maintenance  perspective it is nice to modularize subcommand handling more than they are currently in this project. I did that with conda (and it is still in use today) and also for bokeh. I'd be happy to make a pass at `intake` and `intake-server` (I rather enjoy this sort of cleanup). Let me know what you think. 