### PR TITLE
split intake subcommands

### DIFF
--- a/intake/cli/bootstrap.py
+++ b/intake/cli/bootstrap.py
@@ -1,0 +1,69 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Provide a ``main`` function to run intake commands.
+
+'''
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import argparse
+
+# External imports
+
+# Intake imports
+from intake import __version__
+from intake.cli.util import die, nice_join
+
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+def main(description, subcommands, argv):
+    ''' Execute an intake command.
+
+    Args:
+        description (str) :
+            A description for this top-level command
+
+        subcommands (seq[SubCommand]) :
+            A list of subcommands to configure for argparse
+
+        argv (seq[str]) :
+            A list of command line arguments to process
+
+    Returns:
+        None
+
+    '''
+    if len(argv) == 1:
+        die("ERROR: Must specify subcommand, one of: %s" % nice_join(x.name for x in subcommands))
+
+    parser = argparse.ArgumentParser(
+        prog=argv[0],
+        description=description,
+        epilog="See '<command> --help' to read about a specific subcommand.")
+
+    parser.add_argument('-v', '--version', action='version', version=__version__)
+
+    subs = parser.add_subparsers(help="Sub-commands")
+
+    for cls in subcommands:
+        subparser = subs.add_parser(cls.name, help=cls.__doc__.strip())
+        subcommand = cls(parser=subparser)
+        subparser.set_defaults(invoke=subcommand.invoke)
+
+    args = parser.parse_args(argv[1:])
+    try:
+        return args.invoke(args) or 0 # convert None to 0
+    except Exception as e:
+        die("ERROR: " + repr(e))

--- a/intake/cli/client/subcommands/__init__.py
+++ b/intake/cli/client/subcommands/__init__.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from .cache import Cache
+from .config import Config
+from .describe import Describe
+from .discover import Discover
+from .example import Example
+from .exists import Exists
+from .get import Get
+from .info import Info
+from .list import List
+from .precache import Precache
+
+all  = (Cache, Config, Describe, Discover, Example, Exists, Get, Info, List, Precache)

--- a/intake/cli/client/subcommands/cache.py
+++ b/intake/cli/client/subcommands/cache.py
@@ -1,0 +1,91 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import os
+
+# External imports
+import yaml
+
+# Intake imports
+from intake.cli.util import Subcommand
+
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+class Cache(Subcommand):
+    ''' Locally cached files
+
+    '''
+
+    name = "cache"
+
+    def initialize(self):
+        sub_parser = self.parser.add_subparsers()
+
+        cache_list = sub_parser.add_parser('list-keys', help='List keys currently stored')
+        cache_list.set_defaults(invoke=self._list_keys)
+
+        cache_files = sub_parser.add_parser('list-files', help='List files for a give key')
+        cache_files.add_argument('key', type=str, help='Key to list files for')
+        cache_files.set_defaults(invoke=self._list_files)
+
+        cache_rm = sub_parser.add_parser('clear', help='Clear a key from the cache')
+        cache_rm.add_argument('key', type=str, help='Key to remove (all, if omitted)', nargs='?')
+        cache_rm.set_defaults(invoke=self._clear)
+
+        cache_du = sub_parser.add_parser('usage', help='Print usage information')
+        cache_du.set_defaults(invoke=self._usage)
+
+    def invoke(self, args):
+        self.parser.print_help()
+
+    def _clear(self, args):
+        from intake.source.cache import BaseCache
+        if args.key is None:
+            BaseCache(None, None).clear_all()
+        else:
+            BaseCache(None, None).clear_cache(args.key)
+
+    def _list_keys(self, args):
+        from intake.source.cache import CacheMetadata
+        md = CacheMetadata()
+        print(yaml.dump(list(md), default_flow_style=False))
+
+    def _list_files(self, args):
+        from intake.source.cache import CacheMetadata
+        md = CacheMetadata()
+        print(yaml.dump(md[args.key], default_flow_style=False))
+
+    def _usage(self, args):
+        from intake.config import conf
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(conf['cache_dir']):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                total_size += os.path.getsize(fp)
+        for unit in ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z']:
+            # "human"
+            # https://gist.github.com/cbwar/d2dfbc19b140bd599daccbe0fe925597
+            if abs(total_size) < 1024.0:
+                s = "%3.1f %s" % (total_size, unit)
+                break
+            total_size /= 1024.0
+        print("%s: %s" % (conf['cache_dir'], s))

--- a/intake/cli/client/subcommands/config.py
+++ b/intake/cli/client/subcommands/config.py
@@ -1,0 +1,81 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import os
+
+# External imports
+import yaml
+
+# Intake imports
+from intake.cli.util import Subcommand
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+class Config(Subcommand):
+    ''' Configuration functions
+
+    '''
+
+    name = "config"
+
+    def initialize(self):
+        sub_parser = self.parser.add_subparsers()
+
+        list = sub_parser.add_parser('list-defaults', help='Show all builtin defaults')
+        list.set_defaults(invoke=self._list_defaults)
+
+        conf_reset = sub_parser.add_parser('reset', help='Set config file to defaults')
+        conf_reset.set_defaults(invoke=self._reset)
+
+        conf_info = sub_parser.add_parser('info', help='Show config settings')
+        conf_info.set_defaults(invoke=self._info)
+
+        conf_get = sub_parser.add_parser('get', help='Get current config, specific key or all')
+        conf_get.add_argument('key', type=str, help='Key in config dictionary', nargs='?')
+        conf_get.set_defaults(invoke=self._get)
+
+    def invoke(self, args):
+        self.parser.print_help()
+
+    def _get(self, args):
+            from intake.config import conf
+            if args.key:
+                print(conf[args.key])
+            else:
+                print(yaml.dump(conf, default_flow_style=False))
+
+    def _info(self, args):
+        from intake.config import cfile
+        if 'INTAKE_CONF_DIR' in os.environ:
+            print('INTAKE_CONF_DIR: ', os.environ['INTAKE_CONF_DIR'])
+        if 'INTAKE_CONF_FILE' in os.environ:
+            print('INTAKE_CONF_FILE: ', os.environ['INTAKE_CONF_FILE'])
+        ex = "" if os.path.isfile(cfile()) else "(does not exist)"
+        print('Using: ', cfile(), ex)
+
+    def _list_defaults(self, args):
+        from intake.config import defaults
+        print(yaml.dump(defaults, default_flow_style=False))
+
+    def _reset(self, args):
+        from intake.config import reset_conf, save_conf
+        reset_conf()
+        save_conf()

--- a/intake/cli/client/subcommands/describe.py
+++ b/intake/cli/client/subcommands/describe.py
@@ -3,7 +3,12 @@
 # All rights reserved.
 #
 # The full license is in the LICENSE file, distributed with this software.
-#----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
 
 import logging
 log = logging.getLogger(__name__)
@@ -13,24 +18,28 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 
 # External imports
 
 # Intake imports
-from . import subcommands
+from intake import Catalog
+from intake.cli.util import print_entry_info, Subcommand
 
 #-----------------------------------------------------------------------------
 # API
 #-----------------------------------------------------------------------------
 
-def main(argv=None):
-    ''' Execute the "intake" command line program.
+class Describe(Subcommand):
+    ''' Describe a catalog entry.
 
     '''
-    from intake.cli.bootstrap import main as _main
 
-    return _main('Intake Catalog CLI', subcommands.all, argv or sys.argv)
+    name = "describe"
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    def initialize(self):
+        self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
+        self.parser.add_argument('name', metavar='NAME', type=str, help='Catalog name')
+
+    def invoke(self, args):
+        catalog = Catalog(args.uri)
+        print_entry_info(catalog, args.name)

--- a/intake/cli/client/subcommands/discover.py
+++ b/intake/cli/client/subcommands/discover.py
@@ -3,7 +3,12 @@
 # All rights reserved.
 #
 # The full license is in the LICENSE file, distributed with this software.
-#----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
 
 import logging
 log = logging.getLogger(__name__)
@@ -13,24 +18,29 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 
 # External imports
 
 # Intake imports
-from . import subcommands
+from intake import Catalog
+from intake.cli.util import Subcommand
 
 #-----------------------------------------------------------------------------
 # API
 #-----------------------------------------------------------------------------
 
-def main(argv=None):
-    ''' Execute the "intake" command line program.
+class Discover(Subcommand):
+    ''' Discover a catalog entry
 
     '''
-    from intake.cli.bootstrap import main as _main
 
-    return _main('Intake Catalog CLI', subcommands.all, argv or sys.argv)
+    name = "discover"
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    def initialize(self):
+        self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
+        self.parser.add_argument('name', metavar='NAME', type=str, help='Catalog name')
+
+    def invoke(self, args):
+        catalog = Catalog(args.uri)
+        with catalog[args.name].get() as f:
+            print(f.discover())

--- a/intake/cli/client/subcommands/example.py
+++ b/intake/cli/client/subcommands/example.py
@@ -1,0 +1,65 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+'''
+
+'''
+from __future__ import print_function
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from os.path import dirname, exists, join
+import os, shutil
+
+# External imports
+
+# Intake imports
+from intake.cli.util import Subcommand
+
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+class Example(Subcommand):
+    ''' Create example catalog
+
+    '''
+
+    name = "example"
+
+    def initialize(self):
+        pass
+
+    def invoke(self, args):
+        print('Creating example catalog...')
+        files = ['us_states.yml', 'states_1.csv', 'states_2.csv']
+        for filename in files:
+            if exists(filename):
+                print('Cannot create example catalog in current directory.\n'
+                    '%s already exists.' % filename)
+                return 1
+
+        src_dir = join(dirname(__file__), '..', '..', 'sample')
+
+        for filename in files:
+            src_name = join(src_dir, filename)
+            dest_name = filename
+            dest_dir = dirname(filename)
+            print('  Writing %s' % filename)
+            if dest_dir != '' and not exists(dest_dir):
+                os.mkdir(dest_dir)
+            shutil.copyfile(src_name, dest_name)
+
+        print('''\nTo load the catalog:
+    >>> import intake
+    >>> cat = intake.open_catalog('%s')
+    ''' % files[0])

--- a/intake/cli/client/subcommands/exists.py
+++ b/intake/cli/client/subcommands/exists.py
@@ -3,7 +3,12 @@
 # All rights reserved.
 #
 # The full license is in the LICENSE file, distributed with this software.
-#----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
 
 import logging
 log = logging.getLogger(__name__)
@@ -13,24 +18,28 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 
 # External imports
 
 # Intake imports
-from . import subcommands
+from intake import Catalog
+from intake.cli.util import Subcommand
 
 #-----------------------------------------------------------------------------
 # API
 #-----------------------------------------------------------------------------
 
-def main(argv=None):
-    ''' Execute the "intake" command line program.
+class Exists(Subcommand):
+    ''' Check for the existence of a catalog entry
 
     '''
-    from intake.cli.bootstrap import main as _main
 
-    return _main('Intake Catalog CLI', subcommands.all, argv or sys.argv)
+    name = "exists"
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    def initialize(self):
+        self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
+        self.parser.add_argument('name', metavar='NAME', type=str, help='Catalog name')
+
+    def invoke(self, args):
+        catalog = Catalog(args.uri)
+        print(args.name in catalog)

--- a/intake/cli/client/subcommands/get.py
+++ b/intake/cli/client/subcommands/get.py
@@ -3,7 +3,12 @@
 # All rights reserved.
 #
 # The full license is in the LICENSE file, distributed with this software.
-#----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
 
 import logging
 log = logging.getLogger(__name__)
@@ -13,24 +18,29 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 
 # External imports
 
 # Intake imports
-from . import subcommands
+from intake import Catalog
+from intake.cli.util import Subcommand
 
 #-----------------------------------------------------------------------------
 # API
 #-----------------------------------------------------------------------------
 
-def main(argv=None):
-    ''' Execute the "intake" command line program.
+class Get(Subcommand):
+    ''' Get a catalog entry
 
     '''
-    from intake.cli.bootstrap import main as _main
 
-    return _main('Intake Catalog CLI', subcommands.all, argv or sys.argv)
+    name = "get"
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    def initialize(self):
+        self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
+        self.parser.add_argument('name', metavar='NAME', type=str, help='Catalog name')
+
+    def invoke(self, args):
+        catalog = Catalog(args.uri)
+        with catalog[args.name].get() as f:
+            print(f.read())

--- a/intake/cli/client/subcommands/info.py
+++ b/intake/cli/client/subcommands/info.py
@@ -1,0 +1,58 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from importlib import import_module
+import sys
+
+# External imports
+
+# Intake imports
+from intake import __version__
+from intake.cli.util import Subcommand
+
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+class Info(Subcommand):
+    ''' Display runtime information related to Intake
+
+    '''
+
+    name = "info"
+
+    def initialize(self):
+        pass
+
+    def invoke(self, args):
+        print("Python version      :  %s" % sys.version.split('\n')[0])
+        print("IPython version     :  %s" % _version_from_module('IPython'))
+        print("Tornado version     :  %s" % _version_from_module('tornado', 'version'))
+        print("Dask version        :  %s" % _version_from_module('dask'))
+        print("Pandas version      :  %s" % _version_from_module('pandas'))
+        print("Numpy version       :  %s" % _version_from_module('numpy'))
+        print("Intake version      :  %s" % __version__)
+
+def _version_from_module(modname, version_attr="__version__"):
+    try:
+        mod = import_module(modname)
+        return getattr(mod, version_attr)
+    except ImportError:
+        return "(not installed)"

--- a/intake/cli/client/subcommands/list.py
+++ b/intake/cli/client/subcommands/list.py
@@ -3,7 +3,12 @@
 # All rights reserved.
 #
 # The full license is in the LICENSE file, distributed with this software.
-#----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
 
 import logging
 log = logging.getLogger(__name__)
@@ -13,24 +18,32 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 
 # External imports
 
 # Intake imports
-from . import subcommands
+from intake import Catalog
+from intake.cli.util import print_entry_info, Subcommand
 
 #-----------------------------------------------------------------------------
 # API
 #-----------------------------------------------------------------------------
 
-def main(argv=None):
-    ''' Execute the "intake" command line program.
+class List(Subcommand):
+    ''' Show catalog listing
 
     '''
-    from intake.cli.bootstrap import main as _main
 
-    return _main('Intake Catalog CLI', subcommands.all, argv or sys.argv)
+    name = "list"
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    def initialize(self):
+        self.parser.add_argument('--full', action='store_true')
+        self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
+
+    def invoke(self, args):
+        catalog = Catalog(args.uri)
+        for entry in list(catalog):
+            if args.full:
+                print_entry_info(catalog, entry)
+            else:
+                print(entry)

--- a/intake/cli/client/subcommands/precache.py
+++ b/intake/cli/client/subcommands/precache.py
@@ -3,7 +3,12 @@
 # All rights reserved.
 #
 # The full license is in the LICENSE file, distributed with this software.
-#----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
 
 import logging
 log = logging.getLogger(__name__)
@@ -13,24 +18,31 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 
 # External imports
 
 # Intake imports
-from . import subcommands
+from intake import Catalog
+from intake.cli.util import Subcommand
 
 #-----------------------------------------------------------------------------
 # API
 #-----------------------------------------------------------------------------
 
-def main(argv=None):
-    ''' Execute the "intake" command line program.
+class Precache(Subcommand):
+    ''' Populate caching for catalog entries that define caching.
 
     '''
-    from intake.cli.bootstrap import main as _main
 
-    return _main('Intake Catalog CLI', subcommands.all, argv or sys.argv)
+    name = "precache"
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    def initialize(self):
+        self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
+
+    def invoke(self, args):
+        catalog = Catalog(args.uri)
+        for entry in list(catalog):
+            s = catalog[entry]()
+            if s.cache:
+                print("Caching for entry %s" % entry)
+                s.read()

--- a/intake/cli/client/tests/test_local_integration.py
+++ b/intake/cli/client/tests/test_local_integration.py
@@ -101,7 +101,7 @@ def test_get_fail():
                                stderr=subprocess.PIPE)
     _, err = process.communicate()
 
-    assert "KeyError: 'entry2'" in err.decode('utf-8')
+    assert "KeyError('entry2')" in err.decode('utf-8')
 
 @pytest.fixture
 def temp_current_working_directory():

--- a/intake/cli/tests/__init__.py
+++ b/intake/cli/tests/__init__.py
@@ -1,0 +1,6 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------

--- a/intake/cli/tests/test_util.py
+++ b/intake/cli/tests/test_util.py
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+import pytest
+
+# module under test
+import intake.cli.util as m
+
+# TODO
+def test_print_entry_info():
+    pass
+
+def test_die(capsys):
+    with pytest.raises(SystemExit):
+        m.die("foo")
+    out, err = capsys.readouterr()
+    assert err == "foo\n"
+    assert out == ""
+
+class Test_nice_join(object):
+
+    def test_default(self):
+        assert m.nice_join(["one"]) == "one"
+        assert m.nice_join(["one", "two"]) == "one or two"
+        assert m.nice_join(["one", "two", "three"]) == "one, two or three"
+        assert m.nice_join(["one", "two", "three", "four"]) == "one, two, three or four"
+
+    def test_string_conjunction(self):
+        assert m.nice_join(["one"], conjunction="and") == "one"
+        assert m.nice_join(["one", "two"], conjunction="and") == "one and two"
+        assert m.nice_join(["one", "two", "three"], conjunction="and") == "one, two and three"
+        assert m.nice_join(["one", "two", "three", "four"], conjunction="and") == "one, two, three and four"
+
+    def test_None_conjunction(self):
+        assert m.nice_join(["one"], conjunction=None) == "one"
+        assert m.nice_join(["one", "two"], conjunction=None) == "one, two"
+        assert m.nice_join(["one", "two", "three"], conjunction=None) == "one, two, three"
+        assert m.nice_join(["one", "two", "three", "four"], conjunction=None) == "one, two, three, four"
+
+    def test_sep(self):
+        assert m.nice_join(["one"], sep='; ') == "one"
+        assert m.nice_join(["one", "two"], sep='; ') == "one or two"
+        assert m.nice_join(["one", "two", "three"], sep='; ') == "one; two or three"
+        assert m.nice_join(["one", "two", "three", "four"], sep="; ") == "one; two; three or four"
+
+class TestSubcommand(object):
+
+    def test_initialize_abstract(self):
+        with pytest.raises(NotImplementedError):
+            obj = m.Subcommand("parser")
+            obj.initialize()
+
+    def test_invoke_abstract(self):
+        with pytest.raises(NotImplementedError):
+            obj = m.Subcommand("parser")
+            obj.invoke("args")

--- a/intake/cli/util.py
+++ b/intake/cli/util.py
@@ -79,16 +79,38 @@ def print_entry_info(catalog, name):
         print("[{}] {}={}".format(name, key, info[key]))
 
 class Subcommand(object):
-    '''
+    ''' Abstract base class for subcommands
+
+    Subclasses should define a class variable ``name`` that will be used as the
+    subparser name, and a docstring, that will be used as the subparser help.
+    After initialization, the parser for this comman will be avaialble as
+    ``self.parser``.
+
+    Subclasses must also implement:
+
+    * an ``initialize(self)`` method that configures ``self.parser``
+
+    * an ``invoke(self, args)`` method that accepts a set of argparse
+      processed arguments as input.
 
     '''
 
     def __init__(self, parser):
+        ''' Configure a parser for this command.
+
+        '''
         self.parser = parser
         self.initialize()
 
-    def initialize(self, args):
+    def initialize(self):
+        ''' Implement in subclasses to configure self.parser with any arguments
+        or additional sub-parsers.
+
+        '''
         raise NotImplementedError("Subclasses must implement initialize()")
 
     def invoke(self, args):
+        ''' Implement in subclasses to perform the actual work of the command
+
+        '''
         raise NotImplementedError("Subclasses must implement invoke()")

--- a/intake/cli/util.py
+++ b/intake/cli/util.py
@@ -1,0 +1,94 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Provide a ``main`` function to run intake commands.
+
+'''
+
+from __future__ import print_function
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import sys
+
+# External imports
+
+# Intake imports
+
+
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+def die(message, status=1):
+    ''' Print an error message and exit.
+    This function will call ``sys.exit`` with the given ``status`` and the
+    process will terminate.
+
+    Args:
+        message (str) : error message to print
+
+        status (int) : the exit status to pass to ``sys.exit``
+
+    '''
+    print(message, file=sys.stderr)
+    sys.exit(status)
+
+def nice_join(seq, sep=", ", conjunction="or"):
+    ''' Join together sequences of strings into English-friendly phrases using
+    a conjunction when appropriate.
+
+    Args:
+        seq (seq[str]) : a sequence of strings to nicely join
+
+        sep (str, optional) : a sequence delimiter to use (default: ", ")
+
+        conjunction (str or None, optional) : a conjunction to use for the last
+            two items, or None to reproduce basic join behavior (default: "or")
+
+    Returns:
+        a joined string
+
+    Examples:
+        >>> nice_join(["a", "b", "c"])
+        'a, b or c'
+
+    '''
+    seq = [str(x) for x in seq]
+
+    if len(seq) <= 1 or conjunction is None:
+        return sep.join(seq)
+    else:
+        return "%s %s %s" % (sep.join(seq[:-1]), conjunction, seq[-1])
+
+def print_entry_info(catalog, name):
+    '''
+
+    '''
+    info = catalog[name].describe()
+    for key in sorted(info.keys()):
+        print("[{}] {}={}".format(name, key, info[key]))
+
+class Subcommand(object):
+    '''
+
+    '''
+
+    def __init__(self, parser):
+        self.parser = parser
+        self.initialize()
+
+    def initialize(self, args):
+        raise NotImplementedError("Subclasses must implement initialize()")
+
+    def invoke(self, args):
+        raise NotImplementedError("Subclasses must implement invoke()")


### PR DESCRIPTION
This PR splits the many subcommands of the `intake` command off into their own classes/modules. There is a top level "bootstrap" that processes each class to set up the argument parsers based on the class (the command name is a class variable, the docstring is used for help, and the `invoke` method is wired up)

Some observations: 

* `subcommands.all` could be auto-discovered. Currently there is just a manual list of the command classes there but am happy to make things happen automagically

* There is a mix of return conventions. Some commands return None, or 1, or raise an exception and expect it to propagate all the way to the user (this is under test, more or less). I'd suggest cleaning this up and adopting a single convention. Offhand, I'd say `invoke` should always only return `None` (zero proc return) or raise and exception, which gets caught at the top level and converted to an error message and non-zero proc return. 

* Tests could be split up and moved under `subcommand/tests`. Happy to do this, and also move the test data files to a data subdirectory or something. Just a personal pref, but I prefer non-python modules to be segregated in their own areas. 

* More tests could also be added

Since `intake-server` is only basically one thing, instead of a collection of lots of little things, I didn't do anything with it. 

cc @martindurant 