### PR TITLE
Exclude invalid identifiers from __dir__. Include normal attrs.

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -7,7 +7,9 @@
 
 import collections
 import copy
+import keyword
 import logging
+import re
 import six
 import time
 
@@ -186,7 +188,12 @@ class Catalog(DataSource):
         return key in self._get_entries()  # triggers reload_on_change
 
     def __dir__(self):
-        return list(self)
+        # Include tab-completable entries and normal attributes.
+        return (
+            [entry for entry in self._get_entries() if
+             re.match("[_A-Za-z][_a-zA-Z0-9]*$", entry)  # valid Python identifer
+             and not keyword.iskeyword(entry)]  # not a Python keyword
+            + list(self.__dict__.keys()))
 
     def __repr__(self):
         return "<Intake catalog: %s>" % self.name

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -392,7 +392,7 @@ class RemoteCatalog(Catalog):
         # Include (cached) tab-completable entries and normal attributes.
         warnings.warn(
             "Tab-complete and dir() on RemoteCatalog may include only a "
-            " subset of the available entries.")
+            "subset of the available entries.")
         # Ensure that at least one page of data has been loaded so that *some*
         # entries are included. (If the page has already been cached, this will
         # have effect.)

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -275,20 +275,47 @@ def test_dir(intake_server):
     catalog = Catalog(intake_server, page_size=PAGE_SIZE)
     assert len(catalog._entries._page_cache) == 0
     assert len(catalog._entries._direct_lookup_cache) == 0
+    assert not catalog._entries.complete
+
+    with pytest.warns(UserWarning, match="Tab-complete"):
+        key_completions = catalog._ipython_key_completions_()
     with pytest.warns(UserWarning, match="Tab-complete"):
         dir_ = dir(catalog)
     # __dir__ triggers loading the first page.
     assert len(catalog._entries._page_cache) == 2
     assert len(catalog._entries._direct_lookup_cache) == 0
+    assert not catalog._entries.complete
+    assert set(key_completions) == set(['use_example1', 'nested'])
     assert 'metadata' in dir_  # a normal attribute
     assert 'use_example1' in dir_  # an entry from the first page
     assert 'arr' not in dir_  # an entry we haven't cached yet
+
     # Trigger fetching one specific name.
     catalog['arr']
     with pytest.warns(UserWarning, match="Tab-complete"):
         dir_ = dir(catalog)
+    with pytest.warns(UserWarning, match="Tab-complete"):
+        key_completions = catalog._ipython_key_completions_()
     assert 'metadata' in dir_
     assert 'arr' in dir_  # an entry cached via direct access
+    assert 'arr' in key_completions
+
+    # Load everything.
+    list(catalog)
+    assert catalog._entries.complete
+    with pytest.warns(None) as record:
+        assert set(catalog) == set(catalog._ipython_key_completions_())
+        assert set(catalog).issubset(set(dir(catalog)))
+    assert len(record) == 0
+
+    # Load without pagination (with also loads everything).
+    catalog = Catalog(intake_server, page_size=None)
+    assert catalog._entries.complete
+    with pytest.warns(None) as record:
+        assert set(catalog) == set(catalog._ipython_key_completions_())
+        assert set(catalog).issubset(set(dir(catalog)))
+    assert len(record) == 0
+
 
 def test_getitem_and_getattr(intake_server):
     catalog = Catalog(intake_server)


### PR DESCRIPTION
This also adds a separate `__dir__` implementation for `RemoteCatalog`, as described in #235 and in tests and comments here.

Closes #235.