### PR TITLE
Compute len on server side.

### DIFF
--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -341,3 +341,9 @@ def test_search(intake_server):
 def test_access_subcatalog(intake_server):
     catalog = Catalog(intake_server)
     catalog['nested']
+
+
+def test_len(intake_server):
+    remote_catalog = Catalog(intake_server)
+    local_catalog = Catalog(TEST_CATALOG_PATH)
+    assert sum(1 for entry in local_catalog) == len(remote_catalog)

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -114,8 +114,12 @@ class ServerInfoHandler(tornado.web.RequestHandler):
                     info = source.describe()
                     info['name'] = name
                     sources.append(info)
-
+            try:
+                length = len(cat)
+            except TypeError:
+                length = sum(1 for entry in cat)
             server_info = dict(version=__version__, sources=sources,
+                               length=length,
                                metadata=cat.metadata)
         else:
             msg = 'Access forbidden'


### PR DESCRIPTION
Current behavior in `master` is that `len(catalog)` will cause all the entries to be fetched. The new behavior in this PR computes the length on the server side and sends it in response to `GET /info`. Catalogs may optionally implement `__len__` if they have an efficient means of computing their own length short of iterating over all their entries and counting them up.