### PR TITLE
Include license in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,3 +16,4 @@ include versioneer.py
 include intake/_version.py
 include intake/catalog/tests/example_plugin_dir/example2_source.py
 include requirements.txt
+include LICENSE


### PR DESCRIPTION
The terms of the BSD-2-Clause license require all copies of the software to include the license text