### PR TITLE
Fix missing dependencies when installing with pip

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -8,7 +8,7 @@
 import logging
 import os
 import posixpath
-import yaml
+from ruamel import yaml
 
 try:
     from ruamel.yaml.constructor import DuplicateKeyError

--- a/intake/cli/client/subcommands/cache.py
+++ b/intake/cli/client/subcommands/cache.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 import os
 
 # External imports
-import yaml
+from ruamel import yaml
 
 # Intake imports
 from intake.cli.util import Subcommand

--- a/intake/cli/client/subcommands/config.py
+++ b/intake/cli/client/subcommands/config.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 import os
 
 # External imports
-import yaml
+from ruamel import yaml
 
 # Intake imports
 from intake.cli.util import Subcommand

--- a/intake/config.py
+++ b/intake/config.py
@@ -9,7 +9,8 @@ from os.path import expanduser
 import logging
 import os
 import posixpath
-import yaml
+from ruamel import yaml
+
 from .utils import make_path_posix
 logger = logging.getLogger('intake')
 

--- a/intake/util_tests.py
+++ b/intake/util_tests.py
@@ -13,7 +13,8 @@ import subprocess
 import sys
 import tempfile
 import time
-import yaml
+from ruamel import yaml
+
 from .utils import make_path_posix
 
 ex = sys.executable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # This file is also processed by conda-build, so keep spaces as "pkg >=1.2"
 appdirs
+cloudpickle
 dask >=0.17.0
 holoviews
 jinja2
@@ -11,4 +12,5 @@ python-snappy
 requests
 ruamel.yaml >=0.15.0
 six
+toolz
 tornado >=4.5.1


### PR DESCRIPTION
intake reports missing dependencies (toolz, yaml and cloudpickle) when pip installed from the pypi, or when trying to run tests against current master. This PR fixes that.