### PR TITLE
Raise validation error when parameter has no default

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -390,7 +390,7 @@ class CatalogParser(object):
             'name': name,
             'description': self._getitem(data, 'description', str),
             'type': self._getitem(data, 'type', str, choices=valid_types),
-            'default': self._getitem(data, 'default', object, required=False),
+            'default': self._getitem(data, 'default', object),
             'min': self._getitem(data, 'min', object, required=False),
             'max': self._getitem(data, 'max', object, required=False),
             'allowed': self._getitem(data, 'allowed', object, required=False)

--- a/intake/catalog/tests/params_missing_default.yml
+++ b/intake/catalog/tests/params_missing_default.yml
@@ -1,0 +1,7 @@
+sources:
+  a:
+    driver: csv
+    parameters:
+      b:
+        description: d
+        type: str

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -220,6 +220,7 @@ def test_user_parameter_validation_allowed():
     "data_source_non_dict",
     "data_source_value_non_dict",
     "params_missing_required",
+    "params_missing_default",
     "params_name_non_string",
     "params_non_dict",
     "params_value_bad_choice",


### PR DESCRIPTION
Documentation specifies that 'Every parameter must have a default'. I missed this at first, and had some head scratching errors when the file failed to be found.

If it is indeed the case that default is not optional, I think it is helpful to inform the user when it is missing.