### PR TITLE
Make regex field optional

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -259,12 +259,11 @@ the value when accessing the data.
 Caching Source Files Locally
 ''''''''''''''''''''''''''''
 
-To enable caching on the first read of remote data source files, ``cache`` specifications have the following attributes
-in the catalog.
+To enable caching on the first read of remote data source files, add the ``cache`` section with the
+following attributes:
 
-- ``argkey``: Of the keys in the args section in this same data source, which contains the URL(s) of the data to be cached.
-- ``regex``: A regular expression to match against the URL path, where the matching portion will be replaced by a path in the local cache directory.
-- ``type``: One of the keys in the cache registry [`intake.source.cache.registry`], referring to an implementation of caching behaviour. The default if "file" for the caching of one or more specific remote files.
+- ``argkey``: The args section key which contains the URL(s) of the data to be cached.
+- ``type``: One of the keys in the cache registry [`intake.source.cache.registry`], referring to an implementation of caching behaviour. The default is "file" for the caching of one or more files.
 
 Example:
 
@@ -275,7 +274,6 @@ Example:
     driver: csv
     cache:
       - argkey: urlpath
-        regex: '{{ CATALOG_DIR }}/cache_data'
         type: file
     args:
       urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'
@@ -286,6 +284,11 @@ environment variable, or at runtime using the ``"cache_dir"`` key of the configu
 The special value ``"catdir"`` implies that cached files will appear in the same directory as the
 catalog file in which the data source is defined, within a directory named "intake_cache". These will
 not appear in the cache usage reported by the CLI.
+
+Optionally, the cache section can have a ``regex`` attribute, that modifies the path of the cache on
+the disk. By default, the cache path is made by concatenating ``cache_dir``, dataset name, hash of
+the url, and the url itself (without the protocol). ``regex`` attribute allows to remove part of the
+url (the matching part).
 
 Caching can be disabled at runtime for all sources regardless of the catalog specificiation::
 

--- a/intake/catalog/tests/catalog_caching.yml
+++ b/intake/catalog/tests/catalog_caching.yml
@@ -62,3 +62,21 @@ sources:
         type: file
     args:
       urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'
+  test_regex_no_match:
+    description: regex does not match urlpath
+    driver: csv
+    cache:
+      - argkey: urlpath
+        regex: 'xxx'
+        type: file
+    args:
+      urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'
+  test_regex_partial_match:
+    description: regex matches some part of the url
+    driver: csv
+    cache:
+      - argkey: urlpath
+        regex: '_data'
+        type: file
+    args:
+      urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'

--- a/intake/catalog/tests/catalog_caching.yml
+++ b/intake/catalog/tests/catalog_caching.yml
@@ -54,3 +54,11 @@ sources:
     args:
       path: "{{ CATALOG_DIR }}/small.npy"
       chunks: 5
+  test_no_regex:
+    description: cache a csv file from the local filesystem
+    driver: csv
+    cache:
+      - argkey: urlpath
+        type: file
+    args:
+      urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'

--- a/intake/catalog/tests/test_caching_integration.py
+++ b/intake/catalog/tests/test_caching_integration.py
@@ -8,6 +8,7 @@
 import os
 import pytest
 import shutil
+import string
 import time
 
 import intake
@@ -32,7 +33,6 @@ def test_load_csv(catalog_cache):
     assert os.path.isfile(cache_path)
 
     cache_id = os.path.basename(os.path.dirname(cache_path))
-    import string
     # Checking for md5 hash
     assert all(c in string.hexdigits for c in cache_id)
     cache.clear_all()
@@ -49,7 +49,6 @@ def test_bad_type_cache(catalog_cache):
     assert os.path.isfile(cache_path)
 
     cache_id = os.path.basename(os.path.dirname(cache_path))
-    import string
     # Checking for md5 hash
     assert all(c in string.hexdigits for c in cache_id)
     cache.clear_all()
@@ -66,7 +65,6 @@ def test_load_textfile(catalog_cache):
     assert os.path.isfile(cache_path)
 
     cache_id = os.path.basename(os.path.dirname(cache_path))
-    import string
     # Checking for md5 hash
     assert all(c in string.hexdigits for c in cache_id)
     cache.clear_all()
@@ -83,9 +81,21 @@ def test_load_arr(catalog_cache):
     assert os.path.isfile(cache_path)
 
     cache_id = os.path.basename(os.path.dirname(cache_path))
-    import string
     # Checking for md5 hash
     assert all(c in string.hexdigits for c in cache_id)
+    cache.clear_all()
+
+
+def test_no_regex(catalog_cache):
+    cat = catalog_cache['test_no_regex']
+    cache = cat.cache[0]
+
+    cache_paths = cache.load(cat._urlpath, output=False)
+    cache_path = cache_paths[-1]
+
+    assert cache._cache_dir in cache_path
+    assert os.path.isfile(cache_path)
+
     cache.clear_all()
 
 
@@ -207,7 +217,6 @@ def test_second_load_refresh(catalog_cache):
 
 def test_multiple_cache(catalog_cache):
     cat = catalog_cache['test_multiple_cache']
-    cache = cat.cache[0]
 
     assert len(cat.cache) == 2
 
@@ -242,7 +251,6 @@ def test_disable_caching(catalog_cache):
     assert os.path.isfile(cache_path)
 
     cache_id = os.path.basename(os.path.dirname(cache_path))
-    import string
     # Checking for md5 hash
     assert all(c in string.hexdigits for c in cache_id)
     cache.clear_all()
@@ -266,7 +274,6 @@ def test_ds_set_cache_dir(catalog_cache):
     assert os.path.isfile(cache_path)
 
     cache_id = os.path.basename(os.path.dirname(cache_path))
-    import string
     # Checking for md5 hash
     assert all(c in string.hexdigits for c in cache_id)
     cache.clear_all()

--- a/intake/catalog/tests/test_caching_integration.py
+++ b/intake/catalog/tests/test_caching_integration.py
@@ -86,14 +86,17 @@ def test_load_arr(catalog_cache):
     cache.clear_all()
 
 
-def test_no_regex(catalog_cache):
-    cat = catalog_cache['test_no_regex']
+@pytest.mark.parametrize('section', ['test_no_regex',
+                                     'test_regex_no_match',
+                                     'test_regex_partial_match'])
+def test_regex(catalog_cache, section):
+    cat = catalog_cache[section]
     cache = cat.cache[0]
 
     cache_paths = cache.load(cat._urlpath, output=False)
     cache_path = cache_paths[-1]
 
-    assert cache._cache_dir in cache_path
+    assert cache_path.startswith(cache._cache_dir)
     assert os.path.isfile(cache_path)
 
     cache.clear_all()

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -91,11 +91,15 @@ class BaseCache(object):
     def _munge_path(self, cache_subdir, urlpath):
         import re
 
-        regex = sanitize_path(self._spec['regex'])
         path = sanitize_path(urlpath)
 
+        if 'regex' in self._spec:
+            regex = r'%s' % sanitize_path(self._spec['regex'])
+        else:
+            regex = r'^'  # if no regex provided, use full path
+
         cache_path = re.sub(
-            r"%s" % regex,
+            regex,
             posixpath.join(self._cache_dir, cache_subdir),
             path
         )

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -97,16 +97,9 @@ class BaseCache(object):
 
         if 'regex' in self._spec:
             regex = r'%s' % sanitize_path(self._spec['regex'])
-        else:
-            regex = r'^'  # if no regex provided, use full path
+            path = re.sub(regex, '', path)
 
-        cache_path = re.sub(
-            regex,
-            posixpath.join(self._cache_dir, cache_subdir),
-            path
-        )
-
-        return urlpath if path == cache_path else cache_path
+        return posixpath.join(self._cache_dir, cache_subdir, path.lstrip('/\\'))
 
     def _hash(self, urlpath):
         return md5(

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -34,8 +34,10 @@ def sanitize_path(path):
         # it to match properly.
         path = os.path.normpath(path.replace("{}://".format(protocol), ''))
     elif protocol == 'file':
-        # Just removing trailing slashes from file paths.
+        # Remove trailing slashes from file paths.
         path = os.path.normpath(path)
+        # Remove colons
+        path = path.replace(':', '')
     # Otherwise we just make sure that path is posix
     return make_path_posix(path)
 

--- a/intake/source/tests/test_cache.py
+++ b/intake/source/tests/test_cache.py
@@ -85,13 +85,6 @@ def test_path(file_cache):
     file_cache.clear_all()
 
 
-def test_path_no_match(file_cache):
-    "No match should be a noop."
-    urlpath = 'https://example.com/foo.csv'
-    cache_path = file_cache._path(urlpath)
-    assert urlpath == cache_path
-
-
 def test_dir_cache(tempdir, temp_cache):
     [os.makedirs(os.path.join(tempdir, d)) for d in [
         'main', 'main/sub1', 'main/sub2']]


### PR DESCRIPTION
This PR makes the regex field optional.

The issues of potentially [illegal path](https://github.com/ContinuumIO/intake/issues/265) or file name collisions are not affected by this PR.

Alleviates https://github.com/ContinuumIO/intake/issues/254. It does not fully resolve it, as if user does provide a regex which does not match, files are still dropped in the cwd instead of `cache_dir`.