### PR TITLE
Restore RemoteCatalogEntry.metadata.

### DIFF
--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -39,7 +39,7 @@ class RemoteCatalogEntry(CatalogEntry):
         self.container = container
         self.name = name
         self.description = description
-        self._metadata = metadata
+        self._metadata = metadata or {}
         self._page_size = page_size
         self._user_parameters = user_parameters or []
         self._direct_access = direct_access

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -39,7 +39,7 @@ class RemoteCatalogEntry(CatalogEntry):
         self.container = container
         self.name = name
         self.description = description
-        self.metadata = metadata or {}
+        self._metadata = metadata
         self._page_size = page_size
         self._user_parameters = user_parameters or []
         self._direct_access = direct_access

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -55,6 +55,12 @@ def test_metadata(intake_server):
     assert catalog.version == 1
 
 
+def test_entry_metadata(intake_server):
+    catalog = Catalog(intake_server)
+    entry = catalog['arr']
+    assert entry.metadata == entry().metadata
+
+
 def test_unknown_source(intake_server):
     catalog = Catalog(intake_server)
 


### PR DESCRIPTION
In intake 0.4.1, ``entry.metadata`` works the same on local and remote catalogs: it fires implicit ``entry.get()`` and thus accesses ``entry.get().metadata``.

On current master, local catalog entries still work that way, but remote catalog entries do not. This is because in f1c61db847df092b78e4cc64ebb8d241f0a88a46 I wrongly changed `self._metadata` to `self.metadata` and in effect shadowed the "implicit ``get()``" mechanism.

It seems worth reviewing at some point whether `self._metadata` should exist at all, but in the meantime I think this reversion should be merged to get back to the behavior in 0.4.1. I have added a test to protect against making the same mistake in the future.